### PR TITLE
Fixing python,java,go guestbook samples to mongoDB<->BE

### DIFF
--- a/golang/go-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -26,3 +26,7 @@ spec:
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
           value: guestbook-mongodb:27017
+    initContainers:
+        - name: mongo-init
+          image: busybox:1.28
+          command: ['sh', '-c', 'echo $(date) "> checking for envt var for mongo-service"; until nslookup mongo-service; do echo $(date) "> waiting for mongo"; sleep 2; done; echo $(date) "> got envt var for mongo-service"']

--- a/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -24,3 +24,8 @@ spec:
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
           value: "java-guestbook-mongodb:27017"
+    initContainers:
+        - name: mongo-init
+          image: busybox:1.28
+          command: ['sh', '-c', 'echo $(date) "> checking for envt var for mongo-service"; until nslookup mongo-service; do echo $(date) "> waiting for mongo"; sleep 2; done; echo $(date) "> got envt var for mongo-service"']
+          

--- a/python/python-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/python/python-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -24,3 +24,7 @@ spec:
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
           value: "python-guestbook-mongodb:27017"
+    initContainers:
+        - name: mongo-init
+          image: busybox:1.28
+          command: ['sh', '-c', 'echo $(date) "> checking for envt var for mongo-service"; until nslookup mongo-service; do echo $(date) "> waiting for mongo"; sleep 2; done; echo $(date) "> got envt var for mongo-service"']


### PR DESCRIPTION
There was inconsistent bug that BE was trying to talk to Mongo when Mongo was not ready yet due to kubernetes scheduling.

We apply the fix to all guestbook samples (except node that Sean fixed earlier)
https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/