### PR TITLE
Retry connection to mongoDB

### DIFF
--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -36,7 +36,3 @@ spec:
               key: password
         - name: MONGO_HOST
           value: "mongo-service"
-      initContainers:
-        - name: mongo-init
-          image: busybox:1.28
-          command: ['sh', '-c', 'echo $(date) "> checking for envt var for mongo-service"; until nslookup mongo-service; do echo $(date) "> waiting for mongo"; sleep 2; done; echo $(date) "> got envt var for mongo-service"']

--- a/nodejs/nodejs-guestbook/src/backend/app.js
+++ b/nodejs/nodejs-guestbook/src/backend/app.js
@@ -1,23 +1,7 @@
 const express = require('express')
-const mongoose = require('mongoose')
 const app = express()
 const routes = require('./routes')
 const PORT = process.env.PORT || 8080;
-
-const MONGO_USERNAME = process.env.MONGO_USERNAME || 'root'
-const MONGO_PASSWORD = process.env.MONGO_PASSWORD || 'password'
-const MONGO_HOST = process.env.MONGO_HOST || 'localhost'
-const MONGO_PORT = process.env.MONGO_PORT || '27017'
-
-const MONGO_URI = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/admin`
-
-mongoose.connect(MONGO_URI, {useNewUrlParser: true})
-
-const db = mongoose.connection;
-db.on('error', console.error.bind(console, 'connection err:'));
-db.once('open', function() {
-  console.log('connected to ' + MONGO_URI);
-})
 
 app.use('/', routes)
 // starts an http server on the $PORT environment variable

--- a/nodejs/nodejs-guestbook/src/backend/routes/messages.js
+++ b/nodejs/nodejs-guestbook/src/backend/routes/messages.js
@@ -1,6 +1,17 @@
 const mongoose = require('mongoose')
-const MONGO_URI = process.env.DB_ADDRESS || 'mongodb://localhost:27017/test';
-mongoose.connect(MONGO_URI, { useNewUrlParser: true })
+
+const MONGO_USERNAME = process.env.MONGO_USERNAME || 'root'
+const MONGO_PASSWORD = process.env.MONGO_PASSWORD || 'password'
+const MONGO_HOST = process.env.MONGO_HOST || 'mongo-service'
+const MONGO_PORT = process.env.MONGO_PORT || '27017'
+const MONGO_URI = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/admin`
+mongoose.connect(MONGO_URI, {useNewUrlParser: true})
+
+const db = mongoose.connection;
+db.on('error', console.error.bind(console, 'connection err:'));
+db.once('open', function() {
+  console.log('connected to ' + MONGO_URI);
+})
 
 const messageSchema = mongoose.Schema({
     name: { type: String, required: [true, 'Name is required'] },

--- a/nodejs/nodejs-guestbook/src/backend/routes/messages.js
+++ b/nodejs/nodejs-guestbook/src/backend/routes/messages.js
@@ -5,13 +5,23 @@ const MONGO_PASSWORD = process.env.MONGO_PASSWORD || 'password'
 const MONGO_HOST = process.env.MONGO_HOST || 'mongo-service'
 const MONGO_PORT = process.env.MONGO_PORT || '27017'
 const MONGO_URI = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/admin`
-mongoose.connect(MONGO_URI, {useNewUrlParser: true})
+
+const connectToMongoDB = () => {
+    mongoose.connect(MONGO_URI, {
+        useNewUrlParser: true,
+        connectTimeoutMS: 2000
+    });
+}
+connectToMongoDB();
 
 const db = mongoose.connection;
-db.on('error', console.error.bind(console, 'connection err:'));
-db.once('open', function() {
-  console.log('connected to ' + MONGO_URI);
-})
+db.on('error', (err) => {
+    console.error(`unable to connect to ${MONGO_URI}: ${err}`);
+    connectToMongoDB();
+});
+db.once('open', () => {
+  console.log(`connected to ${MONGO_URI}`);
+});
 
 const messageSchema = mongoose.Schema({
     name: { type: String, required: [true, 'Name is required'] },

--- a/nodejs/nodejs-guestbook/src/backend/routes/messages.js
+++ b/nodejs/nodejs-guestbook/src/backend/routes/messages.js
@@ -6,22 +6,22 @@ const MONGO_HOST = process.env.MONGO_HOST || 'mongo-service'
 const MONGO_PORT = process.env.MONGO_PORT || '27017'
 const MONGO_URI = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/admin`
 
+const db = mongoose.connection;
+db.on('error', (err) => {
+    console.error(`unable to connect to ${MONGO_URI}: ${err}`);
+    setTimeout(connectToMongoDB, 1000);
+});
+db.once('open', () => {
+  console.log(`connected to ${MONGO_URI}`);
+});
+
 const connectToMongoDB = () => {
     mongoose.connect(MONGO_URI, {
         useNewUrlParser: true,
         connectTimeoutMS: 2000
     });
-}
+};
 connectToMongoDB();
-
-const db = mongoose.connection;
-db.on('error', (err) => {
-    console.error(`unable to connect to ${MONGO_URI}: ${err}`);
-    connectToMongoDB();
-});
-db.once('open', () => {
-  console.log(`connected to ${MONGO_URI}`);
-});
 
 const messageSchema = mongoose.Schema({
     name: { type: String, required: [true, 'Name is required'] },


### PR DESCRIPTION
Current code fails to connect to MongoDB most of the time because the database takes more time to start that the node backend.

Because Mongoose doesn't support reconnecting if the first attempt is a fail, we have to retry ourselves.