### PR TITLE
Update launch.json

### DIFF
--- a/golang/go-hello-world/.vscode/launch.json
+++ b/golang/go-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "name": "Debug on Kubernetes",
       "language": "Go",
       "debugPort": 3000,
-      "localRoot": "${workspaceFolder}/cmd/hello-world",
+      "localRoot": "${workspaceFolder}",
       "podSelector": {
         "app": "go-hello-world"
       },


### PR DESCRIPTION
With the latest changes to the VSCode Go Extension, we need to update the `localRoot` property here (only for helloworld app, the guestbook app is working fine.