### PR TITLE
Upgrade django minimum requirement to 2.2.3 due to security

### DIFF
--- a/python/django/python-guestbook/src/requirements.txt
+++ b/python/django/python-guestbook/src/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.2.1
+Django>=2.2.3
 psycopg2==2.8.2
 python-dateutil==2.8.0

--- a/python/django/python-hello-world/src/requirements.txt
+++ b/python/django/python-hello-world/src/requirements.txt
@@ -1,2 +1,2 @@
-Django==2.2.1
+Django>=2.2.3
 psycopg2==2.8.2


### PR DESCRIPTION
Bumped django required version to 2.2.3 due to security vulnerability in earlier versions