### PR TITLE
Add template language metadata to template_location.json

### DIFF
--- a/.templates/template_location.json
+++ b/.templates/template_location.json
@@ -3,60 +3,70 @@
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/python-hello-world",
     "templatePath": "python-hello-world",
-    "templateName": "Python: Hello World"
+    "templateName": "Python: Hello World",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/python-guestbook",
     "templatePath": "python-guestbook",
-    "templateName": "Python: Guestbook"
+    "templateName": "Python: Guestbook",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "golang/go-hello-world",
     "templatePath": "go-hello-world",
-    "templateName": "Go: Hello World"
+    "templateName": "Go: Hello World",
+    "templateLanguages": ["go"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "golang/go-guestbook",
     "templatePath": "go-guestbook",
-    "templateName": "Go: Guestbook"
+    "templateName": "Go: Guestbook",
+    "templateLanguages": ["go"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "nodejs/nodejs-hello-world",
     "templatePath": "nodejs-hello-world",
-    "templateName": "Node.js: Hello World"
+    "templateName": "Node.js: Hello World",
+    "templateLanguages": ["nodejs"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "nodejs/nodejs-guestbook",
     "templatePath": "nodejs-guestbook",
-    "templateName": "Node.js: Guestbook"
+    "templateName": "Node.js: Guestbook",
+    "templateLanguages": ["nodejs"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "java/java-hello-world",
     "templatePath": "java-hello-world",
-    "templateName": "Java: Hello World"
+    "templateName": "Java: Hello World",
+    "templateLanguages": ["java"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "java/java-guestbook",
     "templatePath": "java-guestbook",
-    "templateName": "Java: Guestbook"
+    "templateName": "Java: Guestbook",
+    "templateLanguages": ["java"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "dotnet/dotnet-hello-world",
     "templatePath": "dotnet-hello-world",
-    "templateName": ".NET Core: Hello World"
+    "templateName": ".NET Core: Hello World",
+    "templateLanguages": ["csharp"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "dotnet/dotnet-guestbook",
     "templatePath": "dotnet-guestbook",
-    "templateName": ".NET Core: Guestbook"
+    "templateName": ".NET Core: Guestbook",
+    "templateLanguages": ["csharp"]
   }
 ]

--- a/.templates/template_location.json
+++ b/.templates/template_location.json
@@ -3,25 +3,29 @@
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/python-hello-world",
     "templatePath": "python-hello-world",
-    "templateName": "Python (Flask): Hello World"
+    "templateName": "Python (Flask): Hello World",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/python-guestbook",
     "templatePath": "python-guestbook",
-    "templateName": "Python (Flask): Guestbook"
+    "templateName": "Python (Flask): Guestbook",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/django/python-hello-world",
     "templatePath": "python-hello-world",
-    "templateName": "Python (Django): Hello World"
+    "templateName": "Python (Django): Hello World",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/django/python-guestbook",
     "templatePath": "python-guestbook",
-    "templateName": "Python (Django): Guestbook"
+    "templateName": "Python (Django): Guestbook",
+    "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",


### PR DESCRIPTION
Adding a `templateLanguage` array to each template metadata entry in `template_location.json`.

## Why?

The IDEs may require this knowledge in order to determine which templates to make available to the user in certain contexts. For example, if the user is running in GoLand, we only want to show the `go` templates to the user, as the other ones won't have any language support provided by the IDE.

## Why an array?

Future templates could be multi-service applications with multiple languages, such as [Hipster Shop](https://github.com/GoogleCloudPlatform/microservices-demo)