### PR TITLE
added logic for java tests to use dockerfile profile

### DIFF
--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -16,6 +16,7 @@ steps:
   args:
   - '-c'
   - |
+    # builds java apps with dockerfile profile due to jib/skaffold community builder incompatibility 
     if [ "${_LANG}" = "java" ]
     then
         skaffold run -p dockerfile -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -16,7 +16,12 @@ steps:
   args:
   - '-c'
   - |
-    skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
+    if [ "${_LANG}" = "java" ]
+    then
+        skaffold run -p dockerfile -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
+    else
+        skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
+    fi
   dir: '/workspace/${_DIR}/${_LANG}-${_APP}'
   waitFor: ['create namespace']
 


### PR DESCRIPTION
CI currently fails on Java tests because the [skaffold community cloud builder](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/skaffold) does not have maven installed.
  

This fix runs the skaffold deployment step with the`dockerfile` profile instead of the `cloudbuild` profile for java tests.   