### PR TITLE
give Python Django templates different paths

### DIFF
--- a/.templates/template_location.json
+++ b/.templates/template_location.json
@@ -16,14 +16,14 @@
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/django/python-hello-world",
-    "templatePath": "python-hello-world",
+    "templatePath": "python-django-hello-world",
     "templateName": "Python (Django): Hello World",
     "templateLanguages": ["python"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",
     "directoryPath": "python/django/python-guestbook",
-    "templatePath": "python-guestbook",
+    "templatePath": "python-django-guestbook",
     "templateName": "Python (Django): Guestbook",
     "templateLanguages": ["python"]
   },


### PR DESCRIPTION
The `templatePath` is used in telemetry so we can tell how often samples are used, so we want the paths to be different from the Flask samples'.