### PR TITLE
Simplify Golang images

### DIFF
--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -1,29 +1,19 @@
 # Use base golang image from Docker Hub
-FROM golang:1.12
-
-# Download the dlv (delve) debugger for go (you can comment this out if unused)
-RUN go get -u -v github.com/go-delve/delve/cmd/dlv
+FROM golang:1.12 as build
 
 WORKDIR /src/backend
 
-# Copy the go.mod and go.sum, download the dependencies
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy rest of the application source code
+# Copy application source code
 COPY . ./
+RUN go mod download
 
 # Compile the application to /app/backend.
 RUN go build -o /app/backend .
 
-# If you want to use the debugger, you need to modify the entrypoint to the
-# container and point it to the "dlv debug" command:
-#   * UNCOMMENT the following ENTRYPOINT statement,
-#   * COMMENT OUT the last ENTRYPOINT statement
-# Start the "dlv debug" server on port 3000 of the container.
-ENTRYPOINT ["dlv", "exec", "/app/backend", "--continue", "--accept-multiclient", "--api-version=2", "--headless", "--listen=:3000", "--log"]
-
-# If you want to run WITHOUT the debugging server:
-#   * COMMENT OUT the previous ENTRYPOINT statements,
-#   * UNCOMMENT the following ENTRYPOINT statement.
-# ENTRYPOINT ["/app/backend"]
+# Now create separate deployment image
+FROM gcr.io/distroless/base
+WORKDIR /app
+COPY --from=build /app/backend /app/backend
+# Cause full tracebacks; also serves to identify this image as a Go image for `skaffold debug`
+ENV GOTRACEBACK=all
+ENTRYPOINT ["/app/backend"]

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -1,29 +1,21 @@
 # Use base golang image from Docker Hub
-FROM golang:1.12
-
-# Download the dlv (delve) debugger for go (you can comment this out if unused)
-RUN go get -u -v github.com/go-delve/delve/cmd/dlv
+FROM golang:1.12 as build
 
 WORKDIR /src/frontend
 
-# Copy the go.mod and go.sum, download the dependencies
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy rest of the application source code
+# Copy application source code
 COPY . ./
+RUN go mod download
 
 # Compile the application to /app/frontend.
 RUN go build -o /app/frontend .
 
-# If you want to use the debugger, you need to modify the entrypoint to the
-# container and point it to the "dlv debug" command:
-#   * UNCOMMENT the following ENTRYPOINT statement,
-#   * COMMENT OUT the last ENTRYPOINT statement
-# Start the "dlv debug" server on port 3000 of the container.
-ENTRYPOINT ["dlv", "exec", "/app/frontend", "--continue", "--accept-multiclient", "--api-version=2", "--headless", "--listen=:3000", "--log"]
-
-# If you want to run WITHOUT the debugging server:
-#   * COMMENT OUT the previous ENTRYPOINT statements,
-#   * UNCOMMENT the following ENTRYPOINT statement.
-# ENTRYPOINT ["/app/frontend"]
+# Now create separate deployment image
+FROM gcr.io/distroless/base
+WORKDIR /app
+COPY static /app/static
+COPY templates /app/templates
+COPY --from=build /app/frontend /app/frontend
+# Cause full tracebacks; also serves to identify this image as a Go image for `skaffold debug`
+ENV GOTRACEBACK=all
+ENTRYPOINT ["/app/frontend"]

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -1,29 +1,19 @@
 # Use base golang image from Docker Hub
-FROM golang:1.12
-
-# Download the dlv (delve) debugger for go (you can comment this out if unused)
-RUN go get -u -v github.com/go-delve/delve/cmd/dlv
+FROM golang:1.12 as build
 
 WORKDIR /src/hello-world
 
-# Install dependencies in go.mod and go.sum
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy rest of the application source code
+# Copy application source code
 COPY . ./
+# Install dependencies in go.mod and go.sum
+RUN go mod download
 
 # Compile the application to /app.
 RUN go build -o /app -v ./cmd/hello-world
 
-# If you want to use the debugger, you need to modify the entrypoint to the
-# container and point it to the "dlv debug" command:
-#   * UNCOMMENT the following ENTRYPOINT statement,
-#   * COMMENT OUT the last ENTRYPOINT statement
-# Start the "dlv debug" server on port 3000 of the container.
-ENTRYPOINT ["dlv", "exec", "/app", "--continue", "--accept-multiclient", "--api-version=2", "--headless", "--listen=:3000", "--log"]
-
-# If you want to run WITHOUT the debugging server:
-#   * COMMENT OUT the previous ENTRYPOINT statements,
-#   * UNCOMMENT the following ENTRYPOINT statement.
-# ENTRYPOINT ["/app"]
+# Now create separate deployment image
+FROM gcr.io/distroless/base
+COPY --from=build /app /app
+# Cause full tracebacks; also serves to identify this image as a Go image for `skaffold debug`
+ENV GOTRACEBACK=all
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
- Add `GOTRACEBACK` env var so `skaffold debug` can identify images as golang
- Use multi-stage builds to produce smaller images (as [per distroless[(https://github.com/GoogleContainerTools/distroless#examples-with-docker))