### PR TITLE
Adding init container to node-guestbook

### DIFF
--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -16,8 +16,15 @@ spec:
       labels:
         app: node-guestbook
         tier: backend
-    spec:
-      containers:
+  spec:
+     initContainers:
+      - name: init-db-ready
+        image: mongo:4
+        command: ['/bin/sh', '-c']
+        args:
+          - echo "Waiting for mongodb at node-guestbook-mongodb:27017 to go live before the BE..."; 
+          - until (mongo --host node-guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
+     containers:
       - name: backend
         image: node-guestbook-backend
         ports:

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: node-guestbook
         tier: backend
-  spec:
+    spec:
      initContainers:
       - name: init-db-ready
         image: mongo:4


### PR DESCRIPTION
This change fixes #144 for nodejs only (for now).

Currently it's possible that if kubernetes schedules BE before the DB pod, BE will try to establish connection to the DB and will fail as DB isn't up yet. This will result in error logs on the BE and might lead observers to believe that something doesn't work correctly.

The change introduces initContainer: kubernetes will schedule initContainer with mongo on the same pod where BE is running and let this container execute until it exists before scheduling BE container. In the init container, we ping mongoDB container until it is in the ready state and so it ensures that when BE starts, DB is already started and ready to accept connections.