### PR TITLE
Fix #152 for multimodule projects

### DIFF
--- a/java/java-guestbook/pom.xml
+++ b/java/java-guestbook/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.cloudcode.guestbook</groupId>
     <artifactId>java-guestbook</artifactId>
     <version>1.0</version>
+    <packaging>pom</packaging>
 
     <modules>
         <module>frontend</module>

--- a/java/java-guestbook/skaffold.yaml
+++ b/java/java-guestbook/skaffold.yaml
@@ -6,13 +6,13 @@ build:
   # defines where to find the code at build time and where to push the resulting image
   artifacts:
     - image: java-guestbook-backend
-      context: backend
       # To learn more about how Jib builds Java containers visit
       # https://github.com/GoogleContainerTools/jib
-      jibMaven: {}
+      jibMaven:
+        module: backend
     - image: java-guestbook-frontend
-      context: frontend
-      jibMaven: {}
+      jibMaven:
+        module: frontend
 # defines the Kubernetes manifests to deploy on each run
 deploy:
   kubectl:


### PR DESCRIPTION
- top-level project should have `<packaging>pom</packaging>` since it doesn't produce a jar
- fix specification of Skaffold/Jib multimodule projects: the artifact `context` should point to the root of the maven project (`.` in this case, and so `context` is now omitted), and the `module` should be the relative directory of the sub-project/module