### PR TITLE
Change default external port to 81 for nodejs

### DIFF
--- a/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.yaml
+++ b/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.yaml
@@ -13,5 +13,5 @@ spec:
     app: node-hello-world
   ports:
   - name: http
-    port: 80
+    port: 81
     targetPort: 8080


### PR DESCRIPTION
On windows port 80 might be already occupied by IIS so for practical purposes, we change the default port that hello world sample exposes itself to 81.

Fixes #163 