### PR TITLE
Fix java template for default build

### DIFF
--- a/java/java-guestbook/backend/Dockerfile
+++ b/java/java-guestbook/backend/Dockerfile
@@ -24,4 +24,4 @@ FROM docker.io/openjdk:8-jdk-alpine
 COPY --from=build-env /app/target /app/
 
 # Starts java app with debugging server at port 5005.
-ENTRYPOINT ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y", "-jar", "/app/backend-1.0.jar"]
+ENTRYPOINT ["java", "-jar", "/app/backend-1.0.jar"]

--- a/java/java-guestbook/frontend/Dockerfile
+++ b/java/java-guestbook/frontend/Dockerfile
@@ -24,4 +24,4 @@ FROM docker.io/openjdk:8-jdk-alpine
 COPY --from=build-env /app/target /app/
 
 # Starts java app with debugging server at port 5005.
-ENTRYPOINT ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y", "-jar", "/app/frontend-1.0.jar"]
+ENTRYPOINT ["java", "-jar", "/app/frontend-1.0.jar"]

--- a/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -35,5 +35,7 @@ spec:
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
           value: "java-guestbook-mongodb:27017"
+        # This environment variable enables debugging support for the container.
+        # Remove this to disable the debug build.
         - name: JAVA_TOOL_OPTIONS
           value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y

--- a/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/java/java-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -35,4 +35,5 @@ spec:
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
           value: "java-guestbook-mongodb:27017"
-          
+        - name: JAVA_TOOL_OPTIONS
+          value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y

--- a/java/java-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
+++ b/java/java-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
@@ -28,3 +28,5 @@ spec:
           value: "8080"
         - name: GUESTBOOK_API_ADDR
           value: java-guestbook-backend:8080
+        - name: JAVA_TOOL_OPTIONS
+          value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y

--- a/java/java-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
+++ b/java/java-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
@@ -28,5 +28,7 @@ spec:
           value: "8080"
         - name: GUESTBOOK_API_ADDR
           value: java-guestbook-backend:8080
+        # This environment variable enables debugging support for the container.
+        # Remove this to disable the debug build.
         - name: JAVA_TOOL_OPTIONS
           value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y

--- a/java/java-hello-world/Dockerfile
+++ b/java/java-hello-world/Dockerfile
@@ -24,4 +24,4 @@ FROM openjdk:8-jre-alpine
 COPY --from=build-env /app/target/ /app/
 
 # Starts java app with debugging server at port 5005.
-CMD ["java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y", "-jar", "/app/hello-world-1.0.0.jar"]
+CMD ["java", "-jar", "/app/hello-world-1.0.0.jar"]

--- a/java/java-hello-world/kubernetes-manifests/hello.deployment.yaml
+++ b/java/java-hello-world/kubernetes-manifests/hello.deployment.yaml
@@ -20,3 +20,5 @@ spec:
         env:
         - name: PORT
           value: "8080"
+        - name: JAVA_TOOL_OPTIONS
+          value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y

--- a/java/java-hello-world/kubernetes-manifests/hello.deployment.yaml
+++ b/java/java-hello-world/kubernetes-manifests/hello.deployment.yaml
@@ -20,5 +20,7 @@ spec:
         env:
         - name: PORT
           value: "8080"
+        # This environment variable enables debugging support for the container.
+        # Remove this to disable the debug build.
         - name: JAVA_TOOL_OPTIONS
           value: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y


### PR DESCRIPTION
Debugging on VSCode (by running Cloud Code Deploy and then run Attach configuration), is not working for the default jib build.