### PR TITLE
Make samples objects consistent across languages

### DIFF
--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -42,15 +42,15 @@ steps:
     fi
     echo 'service is' $service
     get_externalIP() {
-      kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}'
+      kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
     }
     until [[ -n "$(get_externalIP)" ]]; do
       echo "Querying for external IP $service"
       sleep 3
     done
 
-    echo "$(get_externalIP)" > _externalIP
-    echo "external IP for $service is $(cat _externalIP)"
+    echo "$(git_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
+    echo "External IP and port for $service is $(cat _externalIP)"
   waitFor: ['Deploy to staging']
 
 - id: 'Integration tests'

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -1,5 +1,5 @@
 steps:
-- id: '${_LANG}-${_APP} Create namespace'
+- id: 'Create namespace'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:
@@ -10,7 +10,7 @@ steps:
     kubectl config view
     kubectl create namespace $$TEST_NAMESPACE
 
-- id: '${_LANG}-${_APP} Deploy to staging'
+- id: 'Deploy to staging'
   name: 'gcr.io/k8s-skaffold/skaffold:latest'
   entrypoint: 'bash'
   args:
@@ -26,7 +26,7 @@ steps:
   dir: '/workspace/${_DIR}/${_LANG}-${_APP}'
   waitFor: ['Create namespace']
 
-- id: '${_LANG}-${_APP} Get Endpoint'
+- id: 'Get Endpoint'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:
@@ -53,7 +53,7 @@ steps:
     echo "external IP for $service is $(cat _externalIP)"
   waitFor: ['Deploy to staging']
 
-- id: '${_LANG}-${_APP} Integration tests'
+- id: 'Integration tests'
   name: 'gcr.io/cloud-builders/curl'
   entrypoint: '/bin/bash'
   args:
@@ -78,7 +78,7 @@ steps:
     ./test_content.sh -r 25 -i 3 -u http://$(cat _externalIP) -k $keyword
   waitFor: ['Get Endpoint']
 
-- id: '${_LANG}-${_APP} Delete namespaces'
+- id: 'Delete namespaces'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -42,7 +42,7 @@ steps:
     fi
     echo 'service is' $service
     get_externalIP() {
-      kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+      kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}'
     }
     until [[ -n "$(get_externalIP)" ]]; do
       echo "Querying for external IP $service"

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -1,5 +1,5 @@
 steps:
-- id: 'Create namespace'
+- id: '${_LANG}-${_APP} Create namespace'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:
@@ -10,7 +10,7 @@ steps:
     kubectl config view
     kubectl create namespace $$TEST_NAMESPACE
 
-- id: 'Deploy to staging'
+- id: '${_LANG}-${_APP} Deploy to staging'
   name: 'gcr.io/k8s-skaffold/skaffold:latest'
   entrypoint: 'bash'
   args:
@@ -26,7 +26,7 @@ steps:
   dir: '/workspace/${_DIR}/${_LANG}-${_APP}'
   waitFor: ['Create namespace']
 
-- id: 'Get Endpoint'
+- id: '${_LANG}-${_APP} Get Endpoint'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:
@@ -34,27 +34,11 @@ steps:
   - |
     if [ "${_APP}" = "hello-world" ]
     then
-        if [ "${_LANG}" = "nodejs" ]
-          then
-          # set nodejs service to use node prefix
-          service=node-${_APP}-external
-        else
-          service=$$HELLO_WORLD_SERVICE
-        fi
+        service=$$HELLO_WORLD_SERVICE
     fi
     if [ "${_APP}" = "guestbook" ]
     then
-        if [ "${_LANG}" = "nodejs" ]
-          then
-          # set nodejs service to use node prefix
-          service=node-${_APP}-frontend
-        elif [ "${_LANG}" = go ]
-          then
-          # set go service to use no prefix
-          service=${_APP}-frontend
-        else
-          service=$$GUESTBOOK_SERVICE
-        fi
+        service=$$GUESTBOOK_SERVICE
     fi
     echo 'service is' $service
     get_externalIP() {
@@ -69,7 +53,7 @@ steps:
     echo "external IP for $service is $(cat _externalIP)"
   waitFor: ['Deploy to staging']
 
-- id: 'Integration tests'
+- id: '${_LANG}-${_APP} Integration tests'
   name: 'gcr.io/cloud-builders/curl'
   entrypoint: '/bin/bash'
   args:
@@ -94,7 +78,7 @@ steps:
     ./test_content.sh -r 25 -i 3 -u http://$(cat _externalIP) -k $keyword
   waitFor: ['Get Endpoint']
 
-- id: 'Delete namespaces'
+- id: '${_LANG}-${_APP} Delete namespaces'
   name: 'gcr.io/cloud-builders/kubectl'
   entrypoint: 'bash'
   args:

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -49,7 +49,7 @@ steps:
       sleep 3
     done
 
-    echo "$(git_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
+    echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
     echo "External IP and port for $service is $(cat _externalIP)"
   waitFor: ['Deploy to staging']
 

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: guestbook-backend
+  name: go-guestbook-backend
   labels:
     app: guestbook
     tier: backend
@@ -22,11 +22,11 @@ spec:
         image: mongo:4
         command: ['/bin/sh', '-c']
         args:
-          - echo "Waiting for mongodb at guestbook-mongodb:27017 to go live before the BE..."; 
-          - until (mongo --host guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
+          - echo "Waiting for mongodb at go-guestbook-mongodb:27017 to go live before the BE..."; 
+          - until (mongo --host go-guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
       containers:
       - name: backend
-        image: guestbook-backend
+        image: go-guestbook-backend
         ports:
         - name: http-server
           containerPort: 8080
@@ -36,4 +36,4 @@ spec:
         - name: PORT
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
-          value: guestbook-mongodb:27017
+          value: go-guestbook-mongodb:27017

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-backend.service.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-backend.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: guestbook-backend
+  name: go-guestbook-backend
   labels:
     app: guestbook
     tier: backend

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: guestbook-frontend
+  name: go-guestbook-frontend
   labels:
     app: guestbook
     tier: frontend
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: guestbook-frontend
+        image: go-guestbook-frontend
         ports:
         - name: http-server
           containerPort: 8080
@@ -29,4 +29,4 @@ spec:
         - name: PORT
           value: "8080"
         - name: GUESTBOOK_API_ADDR
-          value: guestbook-backend:8080
+          value: go-guestbook-backend:8080

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-frontend.service.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-frontend.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: guestbook-frontend
+  name: go-guestbook-frontend
   labels:
     app: guestbook
     tier: frontend

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.deployment.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.deployment.yaml
@@ -6,7 +6,7 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: go=guestbook-mongodb
+  name: go-guestbook-mongodb
   labels:
     app: guestbook
     tier: db

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.deployment.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.deployment.yaml
@@ -6,7 +6,7 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: guestbook-mongodb
+  name: go=guestbook-mongodb
   labels:
     app: guestbook
     tier: db

--- a/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.service.yaml
+++ b/golang/go-guestbook/kubernetes-manifests/guestbook-mongodb.service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: guestbook-mongodb
+  name: go-guestbook-mongodb
   labels:
     app: guestbook
     tier: db

--- a/golang/go-guestbook/skaffold.yaml
+++ b/golang/go-guestbook/skaffold.yaml
@@ -2,9 +2,9 @@ apiVersion: skaffold/v1beta15
 kind: Config
 build:
   artifacts:
-  - image: guestbook-backend
+  - image: go-guestbook-backend
     context: src/backend
-  - image: guestbook-frontend
+  - image: go-guestbook-frontend
     context: src/frontend
   tagPolicy:
     sha256: {}

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-guestbook-backend
+  name: nodejs-guestbook-backend
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: backend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: node-guestbook
+      app: nodejs-guestbook
       tier: backend
   template:
     metadata:
       labels:
-        app: node-guestbook
+        app: nodejs-guestbook
         tier: backend
     spec:
      initContainers:
@@ -22,11 +22,11 @@ spec:
         image: mongo:4
         command: ['/bin/sh', '-c']
         args:
-          - echo "Waiting for mongodb at node-guestbook-mongodb:27017 to go live before the BE..."; 
-          - until (mongo --host node-guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
+          - echo "Waiting for mongodb at nodejs-guestbook-mongodb:27017 to go live before the BE..."; 
+          - until (mongo --host nodejs-guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
      containers:
       - name: backend
-        image: node-guestbook-backend
+        image: nodejs-guestbook-backend
         ports:
         - name: http-server
           containerPort: 8080
@@ -34,4 +34,4 @@ spec:
         - name: PORT
           value: "8080"
         - name: GUESTBOOK_DB_ADDR
-          value: "node-guestbook-mongodb:27017"
+          value: "nodejs-guestbook-mongodb:27017"

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.service.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-guestbook-backend
+  name: nodejs-guestbook-backend
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: backend
 spec:
   type: ClusterIP
   selector:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: backend
   ports:
   - port: 8080

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-frontend.deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-guestbook-frontend
+  name: nodejs-guestbook-frontend
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: frontend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: node-guestbook
+      app: nodejs-guestbook
       tier: frontend
   template:
     metadata:
       labels:
-        app: node-guestbook
+        app: nodejs-guestbook
         tier: frontend
     spec:
       containers:
       - name: frontend
-        image: node-guestbook-frontend
+        image: nodejs-guestbook-frontend
         ports:
         - name: http-server
           containerPort: 8080
@@ -27,4 +27,4 @@ spec:
         - name: PORT
           value: "8080"
         - name: GUESTBOOK_API_ADDR
-          value: node-guestbook-backend:8080
+          value: nodejs-guestbook-backend:8080

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-frontend.service.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-frontend.service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-guestbook-frontend
+  name: nodejs-guestbook-frontend
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: frontend
 spec:
   type: LoadBalancer
   selector:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: frontend
   ports:
   - port: 80

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/mongo.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/mongo.deployment.yaml
@@ -6,20 +6,20 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: node-guestbook-mongodb
+  name: nodejs-guestbook-mongodb
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: db
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: node-guestbook
+      app: nodejs-guestbook
       tier: db
   template:
     metadata:
       labels:
-        app: node-guestbook
+        app: nodejs-guestbook
         tier: db
     spec:
       containers:

--- a/nodejs/nodejs-guestbook/kubernetes-manifests/mongo.service.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/mongo.service.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: db
-  name: node-guestbook-mongodb
+  name: nodejs-guestbook-mongodb
 spec:
   ports:
     - port: 27017
       targetPort: 27017
   selector:
-    app: node-guestbook
+    app: nodejs-guestbook
     tier: db

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -6,9 +6,9 @@ build:
     sha256: {}
   # defines where to find the code at build time and where to push the resulting image
   artifacts:
-  - image: node-guestbook-backend
+  - image: nodejs-guestbook-backend
     context: src/backend
-  - image: node-guestbook-frontend
+  - image: nodejs-guestbook-frontend
     context: src/frontend
 # defines the Kubernetes manifests to deploy on each run
 deploy:

--- a/nodejs/nodejs-hello-world/kubernetes-manifests/hello.deployment.yaml
+++ b/nodejs/nodejs-hello-world/kubernetes-manifests/hello.deployment.yaml
@@ -6,20 +6,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: node-hello-world
+  name: nodejs-hello-world
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: node-hello-world
+      app: nodejs-hello-world
   template:
     metadata:
       labels:
-        app: node-hello-world
+        app: nodejs-hello-world
     spec:
       containers:
         - name: server
-          image: node-hello-world
+          image: nodejs-hello-world
           ports:
           - containerPort: 8080
           env:

--- a/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.yaml
+++ b/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.yaml
@@ -6,11 +6,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: node-hello-world-external
+  name: nodejs-hello-world-external
 spec:
   type: LoadBalancer
   selector:
-    app: node-hello-world
+    app: nodejs-hello-world
   ports:
   - name: http
     port: 81

--- a/nodejs/nodejs-hello-world/skaffold.yaml
+++ b/nodejs/nodejs-hello-world/skaffold.yaml
@@ -5,7 +5,7 @@ build:
     sha256: {}
   artifacts:
   - context: .
-    image: node-hello-world
+    image: nodejs-hello-world
 deploy:
   kubectl:
     manifests:

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
@@ -23,7 +23,7 @@ spec:
       - name: check-db-ready
         image: postgres
         command: ['sh', '-c',
-          'until pg_isready -h python-guestbook-db.default.svc.cluster.local -p 5432;
+          'until pg_isready -h python-guestbook-db -p 5432;
           do echo waiting for database; sleep 2; done;']
       containers:
       - name: frontend

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
@@ -27,9 +27,9 @@ spec:
           do echo waiting for database; sleep 2; done;']
       containers:
       - name: frontend
-        image: python-guestbook-frontend
+        image: python-guestbook-frontend-django
         ports:
-        - http-server
+        - name: http-server
           containerPort: 8080
         env:
         - name: DATABASE_NAME

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.deployment.yaml
@@ -1,21 +1,21 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: python-guestbook-app
+  name: python-guestbook-frontend
   labels:
     app: python-guestbook
-    tier: app
+    tier: frontend
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: python-guestbook
-      tier: app
+      tier: frontend
   template:
     metadata:
       labels:
         app: python-guestbook
-        tier: app
+        tier: frontend
     spec:
       initContainers:
       # Wait for the database to get ready before starting the server, otherwise
@@ -26,10 +26,11 @@ spec:
           'until pg_isready -h python-guestbook-db.default.svc.cluster.local -p 5432;
           do echo waiting for database; sleep 2; done;']
       containers:
-      - name: python-guestbook
-        image: python-guestbook
+      - name: frontend
+        image: python-guestbook-frontend
         ports:
-        - containerPort: 8080
+        - http-server
+          containerPort: 8080
         env:
         - name: DATABASE_NAME
           value: "postgres"

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
@@ -20,7 +20,7 @@ spec:
           do echo waiting for database; sleep 2; done;']
       containers:
       - name: python-guestbook-migration
-        image: python-guestbook-django-migration
+        image: python-guestbook-frontend-django
         command: [ "/bin/sh", "-c", "python manage.py migrate" ]
         env:
         - name: DATABASE_NAME

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
@@ -16,7 +16,7 @@ spec:
       - name: check-db-ready
         image: postgres
         command: ['sh', '-c',
-          'until pg_isready -h python-guestbook-db.default.svc.cluster.local -p 5432;
+          'until pg_isready -h python-guestbook-db -p 5432;
           do echo waiting for database; sleep 2; done;']
       containers:
       - name: python-guestbook-migration

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.migration.yaml
@@ -20,7 +20,7 @@ spec:
           do echo waiting for database; sleep 2; done;']
       containers:
       - name: python-guestbook-migration
-        image: python-guestbook
+        image: python-guestbook-django-migration
         command: [ "/bin/sh", "-c", "python manage.py migrate" ]
         env:
         - name: DATABASE_NAME

--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-app.service.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-app.service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: python-guestbook-app
+  name: python-guestbook-frontend
   labels:
     app: python-guestbook
-    tier: app
+    tier: frontend
 spec:
   type: LoadBalancer
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: http-server
   selector:
     app: python-guestbook
-    tier: app
+    tier: frontend

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   # defines where to find the code at build time and where to push the resulting image
   artifacts:
     - context: src
-      image: python-guestbook
+      image: python-guestbook-frontend-django
 # defines the Kubernetes manifests to deploy on each run
 deploy:
   kubectl:

--- a/python/django/python-hello-world/kubernetes-manifests/hello.deployment.yaml
+++ b/python/django/python-hello-world/kubernetes-manifests/hello.deployment.yaml
@@ -1,7 +1,12 @@
-apiVersion: extensions/v1beta1
+# This Deployment manifest defines:
+# - single-replica deployment of the container image, with label "app: python-hello-world"
+# - Pod exposes port 8080
+# - specify PORT environment variable to the container process
+# Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: python-hello-world-app
+  name: python-hello-world
   labels:
     app: python-hello-world
     tier: app
@@ -22,3 +27,7 @@ spec:
         image: python-hello-world
         ports:
         - containerPort: 8080
+        env:
+        - name: PORT
+          value: "8080"
+

--- a/python/django/python-hello-world/kubernetes-manifests/hello.service.yaml
+++ b/python/django/python-hello-world/kubernetes-manifests/hello.service.yaml
@@ -1,14 +1,20 @@
+# This Service manifest defines:
+# - a load balancer for pods matching label "app: python-hello-world"
+# - exposing the application to the public Internet (type:LoadBalancer)
+# - routes port 80 of the load balancer to the port 8080 of the Pods.
+# Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
 apiVersion: v1
 kind: Service
 metadata:
-  name: python-hello-world-app
+  name: python-hello-world-external
   labels:
     app: python-hello-world
     tier: app
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+  - name: http
+    port: 80
     targetPort: 8080
   selector:
     app: python-hello-world


### PR DESCRIPTION
- Changed go and node samples to comply with the same pattern for object naming.
Example: *go-hello-world* instead of hello-world.
This will help to use the same template for CI across all the languages without IF statements that check for special cases (like it is today)