### PR TITLE
Fixing error messages due to sequencing of pod scheduling on node guestbook

### DIFF
--- a/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
+++ b/nodejs/nodejs-guestbook/kubernetes-manifests/guestbook-backend.deployment.yaml
@@ -22,8 +22,7 @@ spec:
         image: mongo:4
         command: ['/bin/sh', '-c']
         args:
-          - echo "Waiting for mongodb at nodejs-guestbook-mongodb:27017 to go live before the BE..."; 
-          - until (mongo --host nodejs-guestbook-mongodb:27017 >/dev/null) do echo "Waiting for connection for 2 sec."; sleep 2; done
+          - echo "Waiting for mongodb to start...";until (mongo --host nodejs-guestbook-mongodb:27017 >/dev/null 2>&1) do echo "Waiting for connection for 2 sec."; sleep 2; done
      containers:
       - name: backend
         image: nodejs-guestbook-backend

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -14,7 +14,8 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild

--- a/nodejs/nodejs-guestbook/src/backend/routes/messages.js
+++ b/nodejs/nodejs-guestbook/src/backend/routes/messages.js
@@ -4,24 +4,22 @@ const GUESTBOOK_DB_ADDR = process.env.GUESTBOOK_DB_ADDR;
 const mongoURI = "mongodb://" + GUESTBOOK_DB_ADDR + "/guestbook"
 
 const db = mongoose.connection;
-
 db.on('disconnected', () => {
     console.error(`Disconnected: unable to reconnect to ${mongoURI}`)
-    throw new Error(`Disconnected: unable to reconnect to ${mongoURI}`) 
 })
 db.on('error', (err) => {
     console.error(`Unable to connect to ${mongoURI}: ${err}`);
 });
-
 db.once('open', () => {
-  console.log(`connected to ${mongoURI}`);
+  console.log(`Connected to ${mongoURI}`);
 });
 
 const connectToMongoDB = async () => {
     await mongoose.connect(mongoURI, {
         useNewUrlParser: true,
         connectTimeoutMS: 2000,
-        reconnectTries: 1
+        reconnectTries: 5,
+        useUnifiedTopology: true
     })
 };
 


### PR DESCRIPTION
Fixes #212 

A few fixes that will make nodejs template for guestbook more stable in the event of mongodb pod being scheduled after BE by kubernetes:

1) in skaffold.yaml we deploy kubernetes services before kubernetes deployment objects. This ensures that IP addresses of all the deployments will be available by the time deployments are being created for the first time
2) Added connection retries and removed throwing exception in nodejs code that connects to mongodb.
3) Minor change to the initContainer - added redirection of stderror to stdout.