### PR TITLE
Reversing order of applying service and deployment on guestbook apps

### DIFF
--- a/dotnet/dotnet-guestbook/skaffold.yaml
+++ b/dotnet/dotnet-guestbook/skaffold.yaml
@@ -13,7 +13,8 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild

--- a/golang/go-guestbook/skaffold.yaml
+++ b/golang/go-guestbook/skaffold.yaml
@@ -11,7 +11,8 @@ build:
 deploy:
   kubectl:
     manifests:
-    - kubernetes-manifests/**
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 - name: cloudbuild
   build:

--- a/java/java-guestbook/skaffold.yaml
+++ b/java/java-guestbook/skaffold.yaml
@@ -17,7 +17,8 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -11,8 +11,7 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/*.service.yaml
-    - ./kubernetes-manifests/*.deployment.yaml
+    - kubernetes-manifests/**.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -11,7 +11,8 @@ build:
 deploy:
   kubectl:
     manifests:
-      - kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild

--- a/python/python-guestbook/skaffold.yaml
+++ b/python/python-guestbook/skaffold.yaml
@@ -13,7 +13,8 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/*.service.yaml
+    - ./kubernetes-manifests/*.deployment.yaml
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild


### PR DESCRIPTION
Reversing order of applying service and deployment objects on kubernetes in guestbook apps.
This covers python, java, dotnet,go. node is already covered in earlier PR.