### PR TITLE
Consistent use of Go language identifier in the template metadata

### DIFF
--- a/.templates/template_location.json
+++ b/.templates/template_location.json
@@ -61,7 +61,7 @@
     "templatePath": "go-cloud-run-hello-world",
     "templateName": "Golang: Cloud Run Hello World",
     "runPlatforms": ["cloudrun"],
-    "templateLanguages": ["golang"]
+    "templateLanguages": ["go"]
   },
   {
     "repoPath": "https://github.com/GoogleCloudPlatform/cloud-code-samples.git",


### PR DESCRIPTION
The k8s sample use "go". The CR samples use "golang". The extensions hinge on this field for determining which templates are appropriate to show. we should be consistent.