### PR TITLE
Fix attach configuration name

### DIFF
--- a/dotnet/dotnet-guestbook/.vscode/launch.json
+++ b/dotnet/dotnet-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes (frontend)",
+      "name": "Attach to Kubernetes (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "NETCore",
@@ -27,7 +27,7 @@
       }
     },
     {
-      "name": "Debug on Kubernetes (backend)",
+      "name": "Attach to Kubernetes (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "NETCore",

--- a/dotnet/dotnet-guestbook/.vscode/launch.json
+++ b/dotnet/dotnet-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes (frontend)",
+      "name": "Attach to Kubernetes pod (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "NETCore",
@@ -27,7 +27,7 @@
       }
     },
     {
-      "name": "Attach to Kubernetes (backend)",
+      "name": "Attach to Kubernetes pod (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "NETCore",

--- a/dotnet/dotnet-hello-world/.vscode/launch.json
+++ b/dotnet/dotnet-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes",
+      "name": "Attach to Kubernetes",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/dotnet/dotnet-hello-world/.vscode/launch.json
+++ b/dotnet/dotnet-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes",
+      "name": "Attach to Kubernetes pod",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/golang/go-guestbook/.vscode/launch.json
+++ b/golang/go-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes (frontend)",
+      "name": "Attach to Kubernetes pod (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "Attach to Kubernetes (backend)",
+      "name": "Attach to Kubernetes pod (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",

--- a/golang/go-guestbook/.vscode/launch.json
+++ b/golang/go-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes (frontend)",
+      "name": "Attach to Kubernetes (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "Debug on Kubernetes (backend)",
+      "name": "Attach to Kubernetes (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",

--- a/golang/go-hello-world/.vscode/launch.json
+++ b/golang/go-hello-world/.vscode/launch.json
@@ -18,7 +18,7 @@
       "program": "${workspaceFolder}/cmd/hello-world"
     },
     {
-      "name": "Debug on Kubernetes",
+      "name": "Attach to Kubernetes",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",

--- a/golang/go-hello-world/.vscode/launch.json
+++ b/golang/go-hello-world/.vscode/launch.json
@@ -18,7 +18,7 @@
       "program": "${workspaceFolder}/cmd/hello-world"
     },
     {
-      "name": "Attach to Kubernetes",
+      "name": "Attach to Kubernetes pod",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Go",

--- a/java/java-guestbook/.vscode/launch.json
+++ b/java/java-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes (frontend)",
+      "name": "Attach to Kubernetes pod (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Java",
@@ -27,7 +27,7 @@
       }
     },
     {
-      "name": "Attach to Kubernetes (backend)",
+      "name": "Attach to Kubernetes pod (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Java",

--- a/java/java-guestbook/.vscode/launch.json
+++ b/java/java-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes (frontend)",
+      "name": "Attach to Kubernetes (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Java",
@@ -27,7 +27,7 @@
       }
     },
     {
-      "name": "Debug on Kubernetes (backend)",
+      "name": "Attach to Kubernetes (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Java",

--- a/java/java-hello-world/.vscode/launch.json
+++ b/java/java-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
         "portForward": true
       },
       {
-        "name": "Attach to Kubernetes",
+        "name": "Attach to Kubernetes pod",
         "type": "cloudcode.kubernetes",
         "request": "attach",
         "language": "Java",

--- a/java/java-hello-world/.vscode/launch.json
+++ b/java/java-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
         "portForward": true
       },
       {
-        "name": "Debug on Kubernetes",
+        "name": "Attach to Kubernetes",
         "type": "cloudcode.kubernetes",
         "request": "attach",
         "language": "Java",

--- a/nodejs/nodejs-guestbook/.vscode/launch.json
+++ b/nodejs/nodejs-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
             "portForward": true
         },
         {
-            "name": "Attach to Kubernetes pod (Frontend)",
+            "name": "Attach to Kubernetes pod (frontend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {
@@ -24,7 +24,7 @@
             "remoteRoot": "/frontend"
         },
         {
-            "name": "Attach to Kubernetes pod (Backend)",
+            "name": "Attach to Kubernetes pod (backend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {

--- a/nodejs/nodejs-guestbook/.vscode/launch.json
+++ b/nodejs/nodejs-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
             "portForward": true
         },
         {
-            "name": "Attach to Kubernetes (Frontend)",
+            "name": "Attach to Kubernetes pod (Frontend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {
@@ -24,7 +24,7 @@
             "remoteRoot": "/frontend"
         },
         {
-            "name": "Attach to Kubernetes (Backend)",
+            "name": "Attach to Kubernetes pod (Backend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {

--- a/nodejs/nodejs-guestbook/.vscode/launch.json
+++ b/nodejs/nodejs-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
             "portForward": true
         },
         {
-            "name": "Debug Frontend on Kubernetes",
+            "name": "Attach to Kubernetes (Frontend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {
@@ -24,7 +24,7 @@
             "remoteRoot": "/frontend"
         },
         {
-            "name": "Debug Backend on Kubernetes",
+            "name": "Attach to Kubernetes (Backend)",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {

--- a/nodejs/nodejs-hello-world/.vscode/launch.json
+++ b/nodejs/nodejs-hello-world/.vscode/launch.json
@@ -11,7 +11,7 @@
             "portForward": true
         },
         {
-            "name": "Attach to Kubernetes",
+            "name": "Attach to Kubernetes pod",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {

--- a/nodejs/nodejs-hello-world/.vscode/launch.json
+++ b/nodejs/nodejs-hello-world/.vscode/launch.json
@@ -11,7 +11,7 @@
             "portForward": true
         },
         {
-            "name": "Debug on Kubernetes",
+            "name": "Attach to Kubernetes",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "podSelector": {

--- a/python/django/python-guestbook/.vscode/launch.json
+++ b/python/django/python-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes",
+      "name": "Attach to Kubernetes",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/python/django/python-guestbook/.vscode/launch.json
+++ b/python/django/python-guestbook/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes",
+      "name": "Attach to Kubernetes pod",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/python/django/python-hello-world/.vscode/launch.json
+++ b/python/django/python-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes",
+      "name": "Attach to Kubernetes",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/python/django/python-hello-world/.vscode/launch.json
+++ b/python/django/python-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes",
+      "name": "Attach to Kubernetes pod",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/python/python-guestbook/.vscode/launch.json
+++ b/python/python-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes (frontend)",
+      "name": "Attach to Kubernetes (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Python",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "Debug on Kubernetes (backend)",
+      "name": "Attach to Kubernetes (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Python",

--- a/python/python-guestbook/.vscode/launch.json
+++ b/python/python-guestbook/.vscode/launch.json
@@ -11,7 +11,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes (frontend)",
+      "name": "Attach to Kubernetes pod (frontend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Python",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "Attach to Kubernetes (backend)",
+      "name": "Attach to Kubernetes pod (backend)",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "language": "Python",

--- a/python/python-hello-world/.vscode/launch.json
+++ b/python/python-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Debug on Kubernetes",
+      "name": "Attach to Kubernetes",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {

--- a/python/python-hello-world/.vscode/launch.json
+++ b/python/python-hello-world/.vscode/launch.json
@@ -14,7 +14,7 @@
       "portForward": true
     },
     {
-      "name": "Attach to Kubernetes",
+      "name": "Attach to Kubernetes pod",
       "type": "cloudcode.kubernetes",
       "request": "attach",
       "podSelector": {


### PR DESCRIPTION
Currently the attach sample's name is "Debug on Kubernetes". This can be confusing because users can think that this will deploy and debug the application whereas you'll need a running Kubernetes application for this to work.