### PR TITLE
Add environment variable to better support skaffold debug

### DIFF
--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -20,6 +20,9 @@ RUN go build -mod=readonly -v -o /app
 COPY index.html /index.html
 COPY assets ./assets/
 
+# Add stack traces for all user-created goroutines
+ENV GOTRACEBACK=all
+
 # If you want to use the debugger, you need to modify the entrypoint to the
 # container and point it to the "dlv debug" command:
 #   * UNCOMMENT the following ENTRYPOINT statement,

--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -20,8 +20,8 @@ RUN go build -mod=readonly -v -o /app
 COPY index.html /index.html
 COPY assets ./assets/
 
-# Add stack traces for all user-created goroutines
-ENV GOTRACEBACK=all
+# Default behavior - a failure prints a stack trace for the current goroutine
+ENV GOTRACEBACK=single
 
 # If you want to use the debugger, you need to modify the entrypoint to the
 # container and point it to the "dlv debug" command:

--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -20,7 +20,9 @@ RUN go build -mod=readonly -v -o /app
 COPY index.html /index.html
 COPY assets ./assets/
 
-# Default behavior - a failure prints a stack trace for the current goroutine
+# Definition of this variable is used by 'skaffold debug' to identify a golang binary.
+# Default behavior - a failure prints a stack trace for the current goroutine.
+# See https://golang.org/pkg/runtime/
 ENV GOTRACEBACK=single
 
 # If you want to use the debugger, you need to modify the entrypoint to the


### PR DESCRIPTION
`skaffold debug` uses heuristics to determine if an application can be debugged, as described here:
https://skaffold.dev/docs/workflows/debug/

In it's current state, the [Go CR hello-world app](https://github.com/GoogleCloudPlatform/cloud-code-samples/tree/cloudrun-templates/golang) doesn't work with `skaffold debug` without one of the standard go-runtime env vars as explained in the docs.