### PR TITLE
nodejs/Cloud Run Hello World: Debuggable Entrypoint

### DIFF
--- a/nodejs/nodejs-cloud-run-hello-world/Dockerfile
+++ b/nodejs/nodejs-cloud-run-hello-world/Dockerfile
@@ -18,8 +18,5 @@ RUN npm install --production
 # Copy local code to the container image.
 COPY . ./
 
-# Run with debugging on container startup.
-CMD ["npm", "run", "debug"]
-
-# Comment above and uncomment below to run without debugging.
-# CMD [ "npm", "start" ]
+# Run the web service on container startup.
+CMD ["node", "index.js"]

--- a/nodejs/nodejs-cloud-run-hello-world/package.json
+++ b/nodejs/nodejs-cloud-run-hello-world/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "debug": "node --inspect=9229 index.js",
     "lint": "eslint **.js",
     "fix": "eslint --fix *.js",
     "test": "mocha test/*.test.js --check-leaks --timeout 5000"


### PR DESCRIPTION
Fixes #261

### Changes

- Remove commented out options for debug vs. standard entrypoint
- Switch from `npm`-based entrypoint to direct `node` invocation.
