### PR TITLE
Revert "Update dependency com.squareup.okhttp3:okhttp to v4.5.0 (#284)"

### DIFF
--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.5.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Revert "Update dependency com.squareup.okhttp3:okhttp to v4.5.0 (#284)"

This reverts commit e3bcd39e01a21cca21d78c086a317210439e7e8a.

Hey there! We noticed that Java Cloud Run tests started failing after this change was introduced. I haven't looked into _why_ that is, but if the change isn't totally necessary I thought we might revert this for now since it will block our Cloud Code IntelliJ release Monday. I don't have enough context on the change to know if it's safe to revert, just let me know!

Thanks!