### PR TITLE
Fixing Python and Go Cloud Run CI

### DIFF
--- a/golang/.ci/go-cloud-run-hello-world.cloudbuild.yaml
+++ b/golang/.ci/go-cloud-run-hello-world.cloudbuild.yaml
@@ -35,6 +35,7 @@ steps:
     }
     echo $(get_url) > _service_url
     echo "Cloud Run URL for ${_SERVICE} is $(cat _service_url)"
+  dir: 'golang/go-cloud-run-hello-world'
 
 - id: 'Integration Tests'
   name: 'golang:1.14'
@@ -42,7 +43,7 @@ steps:
   args:
   - '-c'
   - |
-    SERVICE_URL=$(cat _service_url) go test -v .
+    export SERVICE_URL=$(cat _service_url) && go test -v .
   dir: 'golang/go-cloud-run-hello-world'
   
 - id: 'Teardown'
@@ -56,6 +57,7 @@ steps:
     gcloud --quiet run services delete ${_SERVICE}-${COMMIT_SHA} --region ${_CLOUDSDK_REGION} --platform managed
     set +x
     echo "View build details in the console: https://console.cloud.google.com/cloud-build/builds/${BUILD_ID}"
+  dir: 'golang/go-cloud-run-hello-world'
 
 # Uncomment if skipping teardown to associate build with container image.
 # images:

--- a/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
 - id: docker build
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_SERVICE-$COMMIT_SHA', '.']
+  dir: 'python/cloud-run-django-hello-world'
 
 - id: docker push
   name: 'gcr.io/cloud-builders/docker'
@@ -43,7 +44,8 @@ steps:
     set -ex
     chmod +x test_content.sh
     ./test_content.sh $(cat _service_url)
-
+  dir: 'python/cloud-run-django-hello-world'
+  
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
   entrypoint: '/bin/bash'

--- a/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
     }
     echo $(get_url) > _service_url
     echo "Cloud Run URL for $_SERVICE is $(cat _service_url)"
+  dir: 'python/cloud-run-django-hello-world'
 
 - id: 'Integration Tests'
   name: 'gcr.io/cloud-builders/curl:latest'
@@ -45,7 +46,7 @@ steps:
     chmod +x test_content.sh
     ./test_content.sh $(cat _service_url)
   dir: 'python/cloud-run-django-hello-world'
-  
+
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
   entrypoint: '/bin/bash'

--- a/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
@@ -63,5 +63,5 @@ images:
 
 substitutions:
   _CLOUDSDK_VERSION: latest
-  _SERVICE: cloud-run-django-hello-world
+  _SERVICE: run-django-helloworld
   _REGION: us-central1

--- a/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
@@ -63,5 +63,5 @@ images:
 
 substitutions:
   _CLOUDSDK_VERSION: latest
-  _SERVICE: cloud-run-python-hello-world
+  _SERVICE: run-python-helloworld
   _REGION: us-central1

--- a/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
     }
     echo $(get_url) > _service_url
     echo "Cloud Run URL for $_SERVICE is $(cat _service_url)"
+  dir: 'python/cloud-run-python-hello-world'
 
 - id: 'Integration Tests'
   name: 'gcr.io/cloud-builders/curl:latest'

--- a/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
 - id: docker build
   name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_SERVICE-$COMMIT_SHA', '.']
+  dir: 'python/cloud-run-python-hello-world'
 
 - id: docker push
   name: 'gcr.io/cloud-builders/docker'
@@ -43,6 +44,7 @@ steps:
     set -ex
     chmod +x test_content.sh
     ./test_content.sh $(cat _service_url)
+  dir: 'python/cloud-run-python-hello-world'
 
 - id: 'Teardown'
   name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'


### PR DESCRIPTION
We add a working dir so Cloud Build CI is not confused when invoking trigger. There is currently no way to specify the working dir for a trigger globally.