### PR TITLE
Increase timeout waiting for MongoDB

### DIFF
--- a/golang/go-guestbook/src/backend/main.go
+++ b/golang/go-guestbook/src/backend/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	mongoURI := "mongodb://" + dbAddr
-	connCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	connCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	dbConn, err := mongo.Connect(connCtx, options.Client().ApplyURI(mongoURI))
 	if err != nil {


### PR DESCRIPTION
When deploying to GKE using Cloud Code, sometimes connection to DB takes longer than 10 seconds so it fails the backend server for debugging.

The error says "ping to mongodb failed: context deadline exceeded". After increasing the timeout, I haven't seen this error.