### PR TITLE
Add environment variable to allow connection

### DIFF
--- a/python/django/python-guestbook/kubernetes-manifests/guestbook-postgres.deployment.yaml
+++ b/python/django/python-guestbook/kubernetes-manifests/guestbook-postgres.deployment.yaml
@@ -28,3 +28,6 @@ spec:
           name: db
           ports:
             - containerPort: 5432
+          env:
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: "trust"


### PR DESCRIPTION
If this is not set, the DB container won't start up. Causes users to not be able to Deploy or to Debug the containers.

Errors I get from GKE container logs:

![image](https://user-images.githubusercontent.com/13400593/81632177-7e48f000-93be-11ea-9e65-1ee1551dd1e2.png)


Relevant PR:
https://github.com/docker-library/postgres/pull/658