### PR TITLE
Update README for the CloudRun command

### DIFF
--- a/dotnet/dotnet-cloud-run-hello-world/README.md
+++ b/dotnet/dotnet-cloud-run-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 

--- a/golang/go-cloud-run-hello-world/README.md
+++ b/golang/go-cloud-run-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 

--- a/java/java-cloud-run-hello-world/README.md
+++ b/java/java-cloud-run-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 

--- a/nodejs/nodejs-cloud-run-hello-world/README.md
+++ b/nodejs/nodejs-cloud-run-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 

--- a/python/cloud-run-django-hello-world/README.md
+++ b/python/cloud-run-django-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 

--- a/python/cloud-run-python-hello-world/README.md
+++ b/python/cloud-run-python-hello-world/README.md
@@ -30,7 +30,7 @@ This sample demonstrates how to use the Cloud Code extension in VS Code.
 ### VS Code Running on Cloud Run
 
 1. Open the command palette
-2. Run `Cloud Code: Deploy to Cloud Run`
+2. Run `Cloud Code - Cloud Run: Deploy`
 
 ## IntelliJ Guide
 


### PR DESCRIPTION
The current version's (v1.3.0) cloud run command is actually `Cloud Code - Cloud Run: Deploy`. 