### PR TITLE
Update Dockerfile to benefit Docker build Caching

### DIFF
--- a/dotnet/dotnet-hello-world/src/Dockerfile
+++ b/dotnet/dotnet-hello-world/src/Dockerfile
@@ -11,12 +11,9 @@ RUN dotnet build "./helloworld.csproj" -c Debug -o /out
 FROM build AS publish
 RUN dotnet publish helloworld.csproj -c Debug -o /out
 
+
 # Building final image used in running container
 FROM base AS final
-WORKDIR /src
-COPY --from=publish /out .
-ENV ASPNETCORE_URLS=http://*:8080
-
 # Installing vsdbg on the container to enable debugging of .NET Core
 RUN apk update \
     && apk add unzip \
@@ -24,5 +21,8 @@ RUN apk update \
     && apk add curl bash \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
+WORKDIR /src
+COPY --from=publish /out .
+ENV ASPNETCORE_URLS=http://*:8080
 
 ENTRYPOINT ["dotnet", "helloworld.dll"]


### PR DESCRIPTION
Moving apk install commands to beginning to cause Docker Image caching to be used every time you are building the code with small changes in Code itself.
