### PR TITLE
Revert org.springframework.boot:spring-boot-starter-parent from 2.3.0.RELEASE to 2.1.4.RELEASE/2.1.2.RELEASE

### DIFF
--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.0.RELEASE</version>
+    <version>2.1.4.RELEASE</version>
   </parent>
 
   <properties>

--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.1.RELEASE</version>
+    <version>2.3.0.RELEASE</version>
   </parent>
 
   <properties>

--- a/java/java-guestbook/backend/pom.xml
+++ b/java/java-guestbook/backend/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.0.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
     </parent>
 
     <properties>

--- a/java/java-guestbook/backend/pom.xml
+++ b/java/java-guestbook/backend/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
     </parent>
 
     <properties>

--- a/java/java-guestbook/frontend/pom.xml
+++ b/java/java-guestbook/frontend/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.0.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
     </parent>
 
     <properties>

--- a/java/java-guestbook/frontend/pom.xml
+++ b/java/java-guestbook/frontend/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>2.3.0.RELEASE</version>
     </parent>
 
     <properties>

--- a/java/java-hello-world/pom.xml
+++ b/java/java-hello-world/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.3.0.RELEASE</version>
 	</parent>
 
 	<properties>

--- a/java/java-hello-world/pom.xml
+++ b/java/java-hello-world/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-code-samples/issues/353