### PR TITLE
Force LF endings for Procfiles as buildpacks bug workaround

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Force Procfiles to always use LFs. This is a temporary workaround that
+# should be removed once https://github.com/GoogleCloudPlatform/buildpacks/issues/56
+# is fixed and included in Skaffold.
+Procfile text eol=lf


### PR DESCRIPTION
Adds a `.gitattributes` file to configure how line endings are treated (https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings).

This addition is mainly to fix a bug where buildpacks aren't able to build and run the Python samples due to the presence of a carriage return in the commands in `Procfile`s. These carriage returns are automatically added when samples are cloned on Windows. The fix is to force no carriage returns for `Procfile`s until https://github.com/GoogleCloudPlatform/buildpacks/issues/56 is fixed.

More context: https://github.com/GoogleCloudPlatform/cloud-code-intellij-internal/issues/2105