### PR TITLE
Update host binding for Python Flask app

### DIFF
--- a/python/cloud-run-python-hello-world/app.py
+++ b/python/cloud-run-python-hello-world/app.py
@@ -38,4 +38,4 @@ def hello():
 
 if __name__ == '__main__':
     server_port = os.environ.get('PORT', '8080')
-    app.run(debug=False, port=server_port, host='0.0.0.0')
+    app.run(debug=False, port=server_port, host='127.0.0.1')


### PR DESCRIPTION
From @steren 's friction log:
https://docs.google.com/document/d/18fNxxeRUiYkRmyNJmTIOda2DjzngizJrUJYJOWfdTlk/edit#

The 0.0.0.0 host is printed by flask on app startup, but the url is not reachable in some systems. Updating to use localhost.