### PR TITLE
Fix getting started links in README.md files

### DIFF
--- a/dotnet/dotnet-cloud-run-hello-world/README.md
+++ b/dotnet/dotnet-cloud-run-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/golang/go-cloud-run-hello-world/README.md
+++ b/golang/go-cloud-run-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)  
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/java/java-cloud-run-hello-world/README.md
+++ b/java/java-cloud-run-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)  
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/nodejs/nodejs-cloud-run-hello-world/README.md
+++ b/nodejs/nodejs-cloud-run-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/python/cloud-run-django-hello-world/README.md
+++ b/python/cloud-run-django-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/python/cloud-run-python-hello-world/README.md
+++ b/python/cloud-run-python-hello-world/README.md
@@ -7,10 +7,10 @@ This "Hello World" is a [Cloud Run](https://cloud.google.com/run/docs) service t
 ## Table of Contents
 
 * [VS Code Guide](#vs-code-guide)
-    1. [Getting Started](#vs-code-getting-started])
+    1. [Getting Started](#vs-code-getting-started)
     2. [Running on Cloud Run](#vs-code-running-on-cloud-run)
 * [IntelliJ Guide](#intellij-guide)
-    1. [Getting Started](#intellij-getting-started])
+    1. [Getting Started](#intellij-getting-started)
     2. [Running on Cloud Run](#intellij-running-on-cloud-run)
 * [Service Configuration](#service-configuration)
 * [Next steps](#next-steps)

--- a/python/django/python-hello-world/README.md
+++ b/python/django/python-hello-world/README.md
@@ -13,7 +13,7 @@
 
 ### Cloud Code for Visual Studio Code
 
-1. [Getting Started](#getting-started])
+1. [Getting Started](#getting-started)
 2. [What's in the box](https://cloud.google.com/code/docs/vscode/quickstart#whats_in_the_box)
 3. Using Cloud Code
     * [Set up a Google Kubernetes Engine Cluster](https://cloud.google.com/code/docs/vscode/quickstart#creating_a_google_kubernetes_engine_cluster)


### PR DESCRIPTION
Internal "Getting Started" links across all Cloud Run samples did not work because of a typo. This PR fixes them.