### PR TITLE
Remove erroneous trailing commas in tasks.json

### DIFF
--- a/nodejs/nodejs-guestbook/.vscode/tasks.json
+++ b/nodejs/nodejs-guestbook/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "run eslint",
             "type": "npm",
-            "script": "lint",
-        },
+            "script": "lint"
+        }
     ]
 }


### PR DESCRIPTION
VS Code can parse this in a forgiving way as JSONC e.g. no linting errors, however Theia cannot.  And it shows as a linting error in the file and in the explorer.  Removal of the tailing commas should resolve this.