### PR TITLE
Spelling fixes in vs code tasks files

### DIFF
--- a/java/java-cloud-run-hello-world/.vscode/tasks.json
+++ b/java/java-cloud-run-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/java/java-guestbook/.vscode/tasks.json
+++ b/java/java-guestbook/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/java/java-hello-world/.vscode/tasks.json
+++ b/java/java-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/cloud-run-django-hello-world/.vscode/tasks.json
+++ b/python/cloud-run-django-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.josn defines quick commands that cam be launched in Visual Studio Code
+    // tasks.josn defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/cloud-run-python-hello-world/.vscode/tasks.json
+++ b/python/cloud-run-python-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.josn defines quick commands that cam be launched in Visual Studio Code
+    // tasks.josn defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/django/python-guestbook/.vscode/tasks.json
+++ b/python/django/python-guestbook/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/django/python-hello-world/.vscode/tasks.json
+++ b/python/django/python-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/python-guestbook/.vscode/tasks.json
+++ b/python/python-guestbook/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {

--- a/python/python-hello-world/.vscode/tasks.json
+++ b/python/python-hello-world/.vscode/tasks.json
@@ -1,4 +1,4 @@
-    // tasks.json defines quick commands that cam be launched in Visual Studio Code
+    // tasks.json defines quick commands that can be launched in Visual Studio Code
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
 {


### PR DESCRIPTION
.vscode task files have spelling of 'cam' instead of 'can' in the comments.