### PR TITLE
Ensure golang images have consistent WORKDIR

### DIFF
--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -1,7 +1,7 @@
 # Use base golang image from Docker Hub
 FROM golang:1.15 AS build
 
-WORKDIR /src/hello-world
+WORKDIR /hello-world
 
 # Install dependencies in go.mod and go.sum
 COPY go.mod go.sum ./

--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Use base golang image from Docker Hub
 FROM golang:1.15 as build
 
-WORKDIR /src/backend
+WORKDIR /app
 
 # Copy the go.mod and go.sum, download the dependencies
 COPY go.mod go.sum ./

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Use base golang image from Docker Hub
 FROM golang:1.15 as build
 
-WORKDIR /src/frontend
+WORKDIR /app
 
 # Copy the go.mod and go.sum, download the dependencies
 COPY go.mod go.sum ./

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -3,7 +3,7 @@
 # Use base golang image from Docker Hub
 FROM golang:1.15 as build
 
-WORKDIR /src/hello-world
+WORKDIR /hello-world
 
 # Install dependencies in go.mod and go.sum
 COPY go.mod go.sum ./


### PR DESCRIPTION
Our golang examples now use a multi-stage build to save approx 800MB of unnecessary baggage (839MB -> 26MB).  But these images currently compile the binary from a different location than where it is run in the result image.  This causes problems for Cloud Code as Golang binaries usually embed the full path of the source.

These patches amend the golang Dockerfiles to use the same WORKDIR for both the build and deployment stages of the images.