### PR TITLE
Wagon retry

### DIFF
--- a/java/java-cloud-run-hello-world/.mvn/jvm.config
+++ b/java/java-cloud-run-hello-world/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/java/java-cloud-run-hello-world/.mvn/wrapper/maven-wrapper.properties
+++ b/java/java-cloud-run-hello-world/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/java/java-guestbook/.mvn/jvm.config
+++ b/java/java-guestbook/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/java/java-guestbook/.mvn/wrapper/maven-wrapper.properties
+++ b/java/java-guestbook/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar

--- a/java/java-hello-world/.mvn/jvm.config
+++ b/java/java-hello-world/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/java/java-hello-world/.mvn/wrapper/maven-wrapper.properties
+++ b/java/java-hello-world/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar


### PR DESCRIPTION
We've been seeing many _connection reset_ failures with Maven fetching artifacts from Maven Central.  Maven's Wagon HTTP maintains a pool of connections and Maven Central (or something in the fetching path) seems to be aggressively closing idle connections.

This PR sets some system properties to configure Maven Wagon HTTP as follows:

  - Dial down the time-to-live on Wagon's pool of HTTP connections to 2 minutes
  - Retry requests even if the request appeared to be received

It also bumps the required Maven version from 3.6.2 to 3.6.3 (latest).