### PR TITLE
[fix] Update Java Samples

### DIFF
--- a/java/java-cloud-run-hello-world/Dockerfile
+++ b/java/java-cloud-run-hello-world/Dockerfile
@@ -1,6 +1,6 @@
-# Use the official maven/Java 8 image to create a build artifact.
+# Use the official maven/Java 11 image to create a build artifact.
 # https://hub.docker.com/_/maven
-FROM maven:3-jdk-8-slim AS build-env
+FROM maven:3-jdk-11-slim AS build-env
 
 # Set the working directory to /app
 WORKDIR /app
@@ -12,11 +12,10 @@ COPY src ./src
 # Download dependencies and build a release artifact.
 RUN mvn package -DskipTests
 
-# Use AdoptOpenJDK for base image.
-# It's important to use OpenJDK 8u191 or above that has container support enabled.
-# https://hub.docker.com/r/adoptopenjdk/openjdk8
+# Use OpenJDK for base image.
+# https://hub.docker.com/_/openjdk
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM adoptopenjdk/openjdk8:alpine-slim
+FROM openjdk:11-slim
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=build-env /app/target/hello-world-*.jar /hello-world.jar

--- a/java/java-cloud-run-hello-world/Dockerfile
+++ b/java/java-cloud-run-hello-world/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn package -DskipTests
 # Use OpenJDK for base image.
 # https://hub.docker.com/_/openjdk
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM openjdk:11-slim
+FROM openjdk:11-jre-slim
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=build-env /app/target/hello-world-*.jar /hello-world.jar

--- a/java/java-guestbook/backend/Dockerfile
+++ b/java/java-guestbook/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use maven to compile the java application.
-FROM docker.io/maven AS build-env
+FROM maven:3-jdk-11-slim AS build-env
 
 # Set the working directory to /app
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY . ./
 RUN mvn -Dmaven.test.skip=true package
 
 # Build runtime image.
-FROM docker.io/openjdk:8-jdk-alpine
+FROM openjdk:11-jre-slim
 
 # Copy the compiled files over.
 COPY --from=build-env /app/target /app/

--- a/java/java-guestbook/frontend/Dockerfile
+++ b/java/java-guestbook/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use maven to compile the java application.
-FROM docker.io/maven AS build-env
+FROM maven:3-jdk-11-slim AS build-env
 
 # Set the working directory to /app
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY . ./
 RUN mvn -Dmaven.test.skip=true package
 
 # Build runtime image.
-FROM docker.io/openjdk:8-jdk-alpine
+FROM openjdk:11-jre-slim
 
 # Copy the compiled files over.
 COPY --from=build-env /app/target /app/

--- a/java/java-hello-world/Dockerfile
+++ b/java/java-hello-world/Dockerfile
@@ -1,5 +1,5 @@
 # Use maven to compile the java application.
-FROM docker.io/maven AS build-env
+FROM maven:3-jdk-11-slim AS build-env
 
 # Set the working directory to /app
 WORKDIR /app
@@ -18,7 +18,7 @@ COPY . ./
 RUN mvn -Dmaven.test.skip=true package
 
 # Build runtime image.
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre-slim
 
 # Copy the compiled files over.
 COPY --from=build-env /app/target/ /app/


### PR DESCRIPTION
Progress towards #604 

* Maven does not have an arm64 image for [maven:3-jdk-8-slim](https://hub.docker.com/_/maven?tab=tags&page=1&ordering=last_updated&name=3-jdk-8), updating to [maven:3-jdk-11-slim](https://hub.docker.com/_/maven?tab=tags&page=1&ordering=last_updated&name=3-jdk-11)
* Since the java version is updated from 8 to 111, the runtime base images are also updated to [openjdk:11-jre-slim](https://hub.docker.com/_/openjdk?tab=tags&page=1&ordering=last_updated&name=11-jre-slim)
* Slim images are used for the runtime base image instead of alpine images because there don't appear to be any arm64 alpine images.

### Samples

- [x] Cloud Run
- [x] Kubernetes: Guestbook
- [x] Kubernetes: Hello World