### PR TITLE
[fix] Update dotnet Samples

### DIFF
--- a/dotnet/dotnet-cloud-run-hello-world/Dockerfile
+++ b/dotnet/dotnet-cloud-run-hello-world/Dockerfile
@@ -2,10 +2,10 @@
 # to ensure optimal image build times and sizes
 # End result container image requires .NET runtime,
 # however creating it requires .NET SDK.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
 WORKDIR /src
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore dotnet-cloud-run-hello-world.csproj
@@ -16,10 +16,8 @@ RUN dotnet publish dotnet-cloud-run-hello-world.csproj -c Debug -o /out
 
 # Building final image used in running container
 FROM base AS final
-RUN apk update \
-    && apk add unzip \
-    && apk add procps \
-    && apk add curl bash \
+RUN apt-get update \
+    && apt-get install -y curl bash unzip procps \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 WORKDIR /src

--- a/dotnet/dotnet-guestbook/src/backend/Dockerfile
+++ b/dotnet/dotnet-guestbook/src/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
 WORKDIR /src
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore backend.csproj
@@ -18,10 +18,8 @@ COPY --from=publish /out .
 ENV ASPNETCORE_URLS=http://*:8080
 
 # Installing vsdbg on the container to enable debugging of .NET Core
-RUN apk update \
-    && apk add unzip \
-    && apk add procps \
-    && apk add curl bash \
+RUN apt-get update \
+    && apt-get install -y unzip procps curl bash \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 

--- a/dotnet/dotnet-guestbook/src/frontend/Dockerfile
+++ b/dotnet/dotnet-guestbook/src/frontend/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
 WORKDIR /src
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore frontend.csproj

--- a/dotnet/dotnet-hello-world/src/Dockerfile
+++ b/dotnet/dotnet-hello-world/src/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS base
 WORKDIR /src
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore helloworld.csproj
@@ -15,10 +15,8 @@ RUN dotnet publish helloworld.csproj -c Debug -o /out
 # Building final image used in running container
 FROM base AS final
 # Installing vsdbg on the container to enable debugging of .NET Core
-RUN apk update \
-    && apk add unzip \
-    && apk add procps \
-    && apk add curl bash \
+RUN apt-get update \
+    && apt-get install -y unzip procps curl bash \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg
 WORKDIR /src

--- a/java/java-cloud-run-hello-world/Dockerfile
+++ b/java/java-cloud-run-hello-world/Dockerfile
@@ -1,6 +1,6 @@
-# Use the official maven/Java 8 image to create a build artifact.
+# Use the official maven/Java 11 image to create a build artifact.
 # https://hub.docker.com/_/maven
-FROM maven:3-jdk-8-slim AS build-env
+FROM maven:3-jdk-11-slim AS build-env
 
 # Set the working directory to /app
 WORKDIR /app
@@ -12,11 +12,10 @@ COPY src ./src
 # Download dependencies and build a release artifact.
 RUN mvn package -DskipTests
 
-# Use AdoptOpenJDK for base image.
-# It's important to use OpenJDK 8u191 or above that has container support enabled.
-# https://hub.docker.com/r/adoptopenjdk/openjdk8
+# Use OpenJDK for base image.
+# https://hub.docker.com/_/openjdk
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM adoptopenjdk/openjdk8:alpine-slim
+FROM openjdk:11-slim
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=build-env /app/target/hello-world-*.jar /hello-world.jar


### PR DESCRIPTION
progress towards #604

* Base image location changed from [mcr.microsoft.com/dotnet/core/aspnet:...](https://hub.docker.com/_/microsoft-dotnet-core-aspnet/) to [mcr.microsoft.com/dotnet/aspnet:...](https://hub.docker.com/_/microsoft-dotnet-aspnet)
* Base image location changed from [mcr.microsoft.com/dotnet/core/sdk:...](https://hub.docker.com/_/microsoft-dotnet-core-sdk) to [mcr.microsoft.com/dotnet/sdk:...](https://hub.docker.com/_/microsoft-dotnet-sdk)
* Image versions changed from `3.1-alpine` to `3.1` because `3.1` has both `x86` and `arm64` versions and the appropriate image gets pulled automatically. The same is not true for their alpine images. This ensures that the same Dockerfile will work on multiple architectures, though it does increase the size of the image produced.

### Samples

- [x] Cloud Run
- [x] Kubernetes: Guestbook
- [x] Kubernetes: Hello World