### PR TITLE
Add timeouts to cloudbuild config files

### DIFF
--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -24,6 +24,7 @@ steps:
         skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     fi
   dir: '/workspace/${_DIR}/${_LANG}-${_APP}'
+  timeout: 1200s
   waitFor: ['Create namespace']
 
 - id: 'Get Endpoint'
@@ -51,6 +52,7 @@ steps:
 
     echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
     echo "External IP and port for $service is $(cat _externalIP)"
+  timeout: 1200s
   waitFor: ['Deploy to staging']
 
 - id: 'Integration tests'
@@ -86,6 +88,7 @@ steps:
   - |
     kubectl delete namespace $$TEST_NAMESPACE
   waitFor: ['Integration tests']
+timeout: 2500s
 
 options:
     env:

--- a/dotnet/.ci/dotnet-hello-world.cloudbuild.yaml
+++ b/dotnet/.ci/dotnet-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/dotnet/dotnet-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:

--- a/golang/.ci/go-hello-world.cloudbuild.yaml
+++ b/golang/.ci/go-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/golang/go-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:

--- a/java/.ci/java-hello-world.cloudbuild.yaml
+++ b/java/.ci/java-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/java/java-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:

--- a/nodejs/.ci/nodejs-hello-world.cloudbuild.yaml
+++ b/nodejs/.ci/nodejs-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/nodejs/nodejs-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:

--- a/python/.ci/django-hello-world.cloudbuild.yaml
+++ b/python/.ci/django-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/python/django/python-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:

--- a/python/.ci/python-hello-world.cloudbuild.yaml
+++ b/python/.ci/python-hello-world.cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     - |
       skaffold run -p cloudbuild -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
     dir: '/workspace/python/python-hello-world'
+    timeout: 1200s
 
   - id: 'Get Endpoint'
     name: 'gcr.io/cloud-builders/kubectl'
@@ -37,6 +38,7 @@ steps:
       done
       echo "$(get_externalIP):$(kubectl get service $service --namespace $$TEST_NAMESPACE -o jsonpath='{.spec.ports[0].port}')" > _externalIP
       echo "External IP and port for $service is $(cat _externalIP)"
+    timeout: 1200s
 
   - id: 'Integration tests'
     name: 'gcr.io/cloud-builders/curl'
@@ -61,6 +63,7 @@ steps:
     - '-c'
     - |
       kubectl delete namespace $$TEST_NAMESPACE
+timeout: 2500s
 
 options:
     env:


### PR DESCRIPTION
Adding the following timeouts to remove test failures due to default 10 minute timeouts:

- build - 2500s
- step: 'Deploy to staging' - 1200s
- step: 'Get Endpoint' - 1200s