### PR TITLE
Adding auth token to Cloud Run tests (#766)

### DIFF
--- a/dotnet/.ci/dotnet-cloud-run-hello-world.cloudbuild.yaml
+++ b/dotnet/.ci/dotnet-cloud-run-hello-world.cloudbuild.yaml
@@ -29,7 +29,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_REGION --platform managed --allow-unauthenticated
+     --region $_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -46,6 +47,23 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'gcr.io/cloud-builders/curl:latest'
   entrypoint: '/bin/bash'
@@ -54,7 +72,7 @@ steps:
   - |
     set -ex
     chmod +x test/test_content.sh
-    test/test_content.sh $(cat _service_url)
+    test/test_content.sh $(cat _service_url) $(cat _id_token)
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Teardown'

--- a/dotnet/dotnet-cloud-run-hello-world/test/test_content.sh
+++ b/dotnet/dotnet-cloud-run-hello-world/test/test_content.sh
@@ -16,13 +16,14 @@
 
 PORT=${PORT:-8080}
 url=${1:-'http://localhost:$PORT'}
+token=${2:-''}
 expected='Congratulations, you successfully deployed a container image to Cloud Run'
 retries=10
 interval=5
 
 for i in $(seq 0 $retries); do
     
-    html="$(curl -si $url)" || html=""
+    html="$(curl -si $url -H "Authorization: Bearer $token")" || html=""
     
     if echo "$html" | grep -q "$expected"
     then

--- a/golang/.ci/go-cloud-run-hello-world.cloudbuild.yaml
+++ b/golang/.ci/go-cloud-run-hello-world.cloudbuild.yaml
@@ -29,7 +29,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_REGION --platform managed --allow-unauthenticated
+     --region $_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -46,13 +47,30 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'golang:1.14'
   entrypoint: '/bin/bash'
   args:
   - '-c'
   - |
-    export SERVICE_URL=$(cat _service_url) && go test -v .
+    export SERVICE_URL=$(cat _service_url) && export TOKEN=$(cat _id_token) && go test -v .
   dir: '${_SAMPLE_DIR}'
   
 - id: 'Teardown'

--- a/golang/go-cloud-run-hello-world/go.sum
+++ b/golang/go-cloud-run-hello-world/go.sum
@@ -169,6 +169,7 @@ github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/golang/go-cloud-run-hello-world/main_test.go
+++ b/golang/go-cloud-run-hello-world/main_test.go
@@ -21,9 +21,20 @@ func TestService(t *testing.T) {
 		url = "http://localhost:" + port
 	}
 
-	resp, err := retry.Get(url + "/")
+	retryClient := retry.NewClient()
+	req, err := retry.NewRequest(http.MethodGet, url+"/", nil)
 	if err != nil {
-		t.Fatalf("retry.Get: %v", err)
+		t.Fatalf("retry.NewRequest: %v", err)
+	}
+
+	token := os.Getenv("TOKEN")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := retryClient.Do(req)
+	if err != nil {
+		t.Fatalf("retryClient.Do: %v", err)
 	}
 
 	if got := resp.StatusCode; got != http.StatusOK {

--- a/java/.ci/java-cloud-run-hello-world.cloudbuild.yaml
+++ b/java/.ci/java-cloud-run-hello-world.cloudbuild.yaml
@@ -29,7 +29,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_CLOUDSDK_REGION --platform managed --allow-unauthenticated
+     --region $_CLOUDSDK_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -46,13 +47,30 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'maven:latest'
   entrypoint: '/bin/bash'
   args:
   - '-c'
   - |
-    export SERVICE_URL=$(cat _service_url) && mvn verify
+    export SERVICE_URL=$(cat _service_url) && export TOKEN=$(cat _id_token) && mvn verify
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Teardown'
@@ -62,7 +80,7 @@ steps:
   - '-c'
   - |
     set -ex
-    gcloud --quiet container images delete gcr.io/${PROJECT_ID}/${_SERVICE}:${COMMIT_SHA}
+    gcloud --quiet container images delete gcr.io/${PROJECT_ID}/${_SERVICE}:${COMMIT_SHA} --force-delete-tags
     gcloud --quiet run services delete $_SERVICE-$(cat _RND) --region ${_CLOUDSDK_REGION} --platform managed
   dir: '${_SAMPLE_DIR}'
 

--- a/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
+++ b/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
@@ -36,6 +36,8 @@ public class HelloWorldControllerIT {
       url = "http://localhost:" + port;
     }
 
+    String token = System.getenv("TOKEN");
+
     OkHttpClient ok =
         new OkHttpClient.Builder()
             .connectTimeout(20, TimeUnit.SECONDS)
@@ -43,7 +45,7 @@ public class HelloWorldControllerIT {
             .writeTimeout(20, TimeUnit.SECONDS)
             .build();
 
-    Request request = new Request.Builder().url(url + "/").get().build();
+    Request request = new Request.Builder().url(url + "/").header("Authorization", "Bearer " + token).get().build();
 
     String expected = "Congratulations, you successfully deployed a container image to Cloud Run";
     Response response = ok.newCall(request).execute();

--- a/nodejs/.ci/nodejs-cloud-run-hello-world.cloudbuild.yaml
+++ b/nodejs/.ci/nodejs-cloud-run-hello-world.cloudbuild.yaml
@@ -39,7 +39,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_REGION --platform managed --allow-unauthenticated
+     --region $_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -57,13 +58,30 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'node:12-slim'
   entrypoint: '/bin/bash'
   args:
   - '-c'
   - |
-    SERVICE_URL=$(cat _service_url) npm test
+    SERVICE_URL=$(cat _service_url) TOKEN=$(cat _id_token) npm test
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Teardown'

--- a/nodejs/nodejs-cloud-run-hello-world/test/system.test.js
+++ b/nodejs/nodejs-cloud-run-hello-world/test/system.test.js
@@ -3,12 +3,14 @@ const {request} = require('gaxios');
 
 const port = process.env.PORT || '8080';
 const url = process.env.SERVICE_URL || `http://localhost:${port}`;
+const token = process.env.TOKEN || '';
 
 describe('Hello World', () => {
   it('can respond to an HTTP request', async () => {
-    console.log(`    - Requesting GET ${url}/...`)
+    console.log(`    - Requesting GET ${url}/...`);
     const res = await request({
       url: url + '/',
+      headers: {"Authorization": "Bearer " + token},
       timeout: 5000,
     });
 

--- a/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-django-hello-world.cloudbuild.yaml
@@ -29,7 +29,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_REGION --platform managed --allow-unauthenticated
+     --region $_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -46,6 +47,23 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'gcr.io/cloud-builders/curl:latest'
   entrypoint: '/bin/bash'
@@ -54,7 +72,7 @@ steps:
   - |
     set -ex
     chmod +x test_content.sh
-    ./test_content.sh $(cat _service_url)
+    ./test_content.sh $(cat _service_url) $(cat _id_token)
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Teardown'

--- a/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
+++ b/python/.ci/cloud-run-python-hello-world.cloudbuild.yaml
@@ -29,7 +29,8 @@ steps:
   - |
     gcloud run deploy $_SERVICE-$(cat _RND) \
      --image gcr.io/$PROJECT_ID/$_SERVICE:$COMMIT_SHA \
-     --region $_REGION --platform managed --allow-unauthenticated
+     --region $_REGION --platform managed --no-allow-unauthenticated \
+     --service-account $_SERVICE_ACCOUNT
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Get Cloud Run URL'
@@ -46,6 +47,23 @@ steps:
     echo "Cloud Run URL for $_SERVICE-$(cat _RND) is $(cat _service_url)"
   dir: '${_SAMPLE_DIR}'
 
+- id: 'Get Identity Token'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    echo "Getting identity token with service account $_SERVICE_ACCOUNT..."
+    get_id_token() {
+      curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d "{\"audience\": \"$(cat _service_url)\"}" \
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${_SERVICE_ACCOUNT}:generateIdToken" | \
+        python3 -c "import sys, json; print(json.load(sys.stdin)['token'])"
+    }
+    echo $(get_id_token) > _id_token
+  dir: '${_SAMPLE_DIR}'
+
 - id: 'Integration Tests'
   name: 'gcr.io/cloud-builders/curl:latest'
   entrypoint: '/bin/bash'
@@ -54,7 +72,7 @@ steps:
   - |
     set -ex
     chmod +x test_content.sh
-    ./test_content.sh $(cat _service_url)
+    ./test_content.sh $(cat _service_url) $(cat _id_token)
   dir: '${_SAMPLE_DIR}'
 
 - id: 'Teardown'

--- a/python/cloud-run-django-hello-world/test_content.sh
+++ b/python/cloud-run-django-hello-world/test_content.sh
@@ -16,13 +16,14 @@
 
 PORT=${PORT:-8080}
 url=${1:-'http://localhost:$PORT'}
+token=${2:-''}
 expected='you successfully deployed a container image to Cloud Run'
 retries=10
 interval=5
 
 for i in $(seq 0 $retries); do
 
-    html="$(curl -si $url)" || html=""
+    html="$(curl -si $url -H "Authorization: Bearer $token")" || html=""
 
     if echo "$html" | grep -q "$expected"
     then

--- a/python/cloud-run-python-hello-world/test_content.sh
+++ b/python/cloud-run-python-hello-world/test_content.sh
@@ -16,13 +16,14 @@
 
 PORT=${PORT:-8080}
 url=${1:-'http://localhost:'$PORT}
+token=${2:-''}
 expected='you successfully deployed a container image to Cloud Run'
 retries=10
 interval=5
 
 for i in $(seq 0 $retries); do
 
-    html="$(curl -si $url)" || html=""
+    html="$(curl -si $url -H "Authorization: Bearer $token")" || html=""
 
     if echo "$html" | grep -q "$expected"
     then


### PR DESCRIPTION
Fixes #759 

Updates the integration tests for the Cloud Run Hello World samples, by adding a Cloud build step to generate a temporary id token which is used to authenticate the test's HTTP request to the service.