### PR TITLE
Update Skaffold schema version

### DIFF
--- a/dotnet/dotnet-guestbook/skaffold.yaml
+++ b/dotnet/dotnet-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/dotnet/dotnet-guestbook/skaffold.yaml
+++ b/dotnet/dotnet-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/dotnet/dotnet-guestbook/skaffold.yaml
+++ b/dotnet/dotnet-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/dotnet/dotnet-hello-world/skaffold.yaml
+++ b/dotnet/dotnet-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/dotnet/dotnet-hello-world/skaffold.yaml
+++ b/dotnet/dotnet-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/dotnet/dotnet-hello-world/skaffold.yaml
+++ b/dotnet/dotnet-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/golang/go-guestbook/skaffold.yaml
+++ b/golang/go-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   artifacts:

--- a/golang/go-guestbook/skaffold.yaml
+++ b/golang/go-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   artifacts:

--- a/golang/go-guestbook/skaffold.yaml
+++ b/golang/go-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   artifacts:

--- a/golang/go-hello-world/skaffold.yaml
+++ b/golang/go-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/golang/go-hello-world/skaffold.yaml
+++ b/golang/go-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/golang/go-hello-world/skaffold.yaml
+++ b/golang/go-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/java/java-guestbook/skaffold.yaml
+++ b/java/java-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/java/java-guestbook/skaffold.yaml
+++ b/java/java-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/java/java-guestbook/skaffold.yaml
+++ b/java/java-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/java/java-hello-world/skaffold.yaml
+++ b/java/java-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/java/java-hello-world/skaffold.yaml
+++ b/java/java-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/java/java-hello-world/skaffold.yaml
+++ b/java/java-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -35,9 +35,9 @@ profiles:
     artifacts:
     - image: nodejs-guestbook-backend
       context: src/backend
-      buildpack:
+      buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
     - image: nodejs-guestbook-frontend
       context: src/frontend
-      buildpack:
+      buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-guestbook/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-hello-world/skaffold.yaml
+++ b/nodejs/nodejs-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-hello-world/skaffold.yaml
+++ b/nodejs/nodejs-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/nodejs/nodejs-hello-world/skaffold.yaml
+++ b/nodejs/nodejs-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-guestbook/skaffold.yaml
+++ b/python/django/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-hello-world/skaffold.yaml
+++ b/python/django/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-hello-world/skaffold.yaml
+++ b/python/django/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/python/django/python-hello-world/skaffold.yaml
+++ b/python/django/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/python/python-guestbook/skaffold.yaml
+++ b/python/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/python/python-guestbook/skaffold.yaml
+++ b/python/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/python/python-guestbook/skaffold.yaml
+++ b/python/python-guestbook/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:

--- a/python/python-hello-world/skaffold.yaml
+++ b/python/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta16
+apiVersion: skaffold/v2beta19
 kind: Config
 build:
   tagPolicy:

--- a/python/python-hello-world/skaffold.yaml
+++ b/python/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta4
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   tagPolicy:

--- a/python/python-hello-world/skaffold.yaml
+++ b/python/python-hello-world/skaffold.yaml
@@ -1,6 +1,6 @@
 # To learn more about the skaffold.yaml schema visit
 # https://skaffold.dev/docs/references/yaml/
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta16
 kind: Config
 build:
   tagPolicy:


### PR DESCRIPTION
- Updates the schema version of all Skaffold files to ~`v2beta22`~ `v2beta19`
- Changes `buildpack` to `buildpacks`

Since the `master` branch is deprecated, the schema version is set to the version compatible with Cloud Code effective August 2021.