### PR TITLE
Revert "chore(deps): update golang docker tag to v1.17"

### DIFF
--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -1,5 +1,5 @@
 # Use base golang image from Docker Hub
-FROM golang:1.17 AS build
+FROM golang:1.16 AS build
 
 WORKDIR /hello-world
 

--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use base golang image from Docker Hub
-FROM golang:1.17 as build
+FROM golang:1.16 as build
 
 WORKDIR /app
 

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use base golang image from Docker Hub
-FROM golang:1.17 as build
+FROM golang:1.16 as build
 
 WORKDIR /app
 

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -1,7 +1,7 @@
 # Go binaries are standalone, so use a multi-stage build to produce smaller images.
 
 # Use base golang image from Docker Hub
-FROM golang:1.17 as build
+FROM golang:1.16 as build
 
 WORKDIR /hello-world
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-code-samples#791

Go version 1.17 is not supported yet.