### PR TITLE
Add note for Skaffold Modules in VS Code

### DIFF
--- a/dotnet/dotnet-guestbook/.readmes/vscode/README.md
+++ b/dotnet/dotnet-guestbook/.readmes/vscode/README.md
@@ -35,7 +35,10 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+### Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -85,6 +88,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 ![image](./img/kubernetes-guestbook-url.png)
 
 ### Run individual services with Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/golang/go-guestbook/.readmes/vscode/README.md
+++ b/golang/go-guestbook/.readmes/vscode/README.md
@@ -35,7 +35,10 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+### Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -85,6 +88,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 ![image](./img/kubernetes-guestbook-url.png)
 
 ### Run individual services with Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/java/java-guestbook/.readmes/vscode/README.md
+++ b/java/java-guestbook/.readmes/vscode/README.md
@@ -35,7 +35,10 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+### Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -85,6 +88,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 ![image](./img/kubernetes-guestbook-url.png)
 
 ### Run individual services with Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/nodejs/nodejs-guestbook/.readmes/vscode/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/vscode/README.md
@@ -35,7 +35,10 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+### Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -85,6 +88,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 ![image](./img/kubernetes-guestbook-url.png)
 
 ### Run individual services with Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/python/python-guestbook/.readmes/vscode/README.md
+++ b/python/python-guestbook/.readmes/vscode/README.md
@@ -35,7 +35,10 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+### Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -85,6 +88,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 ![image](./img/kubernetes-guestbook-url.png)
 
 ### Run individual services with Skaffold modules
+
+>  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 


### PR DESCRIPTION
For VS Code release 1.16.0, skaffold modules will remain part of the Insiders build.

The docs have been updated with a note directing users to the insiders release documentation in order to try out modules on VS Code.

This note will be removed when modules are added to the next release.