### PR TITLE
Fix maven parent relative path

### DIFF
--- a/java/java-guestbook/backend/pom.xml
+++ b/java/java-guestbook/backend/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
     <version>2.5.6</version>
+    <relativePath/>
   </parent>
 
   <properties>

--- a/java/java-guestbook/frontend/pom.xml
+++ b/java/java-guestbook/frontend/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
       <version>2.5.6</version>
+    <relativePath/>
   </parent>
 
   <properties>


### PR DESCRIPTION
Fixes #883 

Adds empty `relativePath` to avoid Maven error resolving parent and look in the repository instead. See more here https://stackoverflow.com/questions/6003831/parent-relativepath-points-at-my-com-mycompanymyproject-instead-of-org-apache