### PR TITLE
Add warning message to Java Guestbook frontend

### DIFF
--- a/java/java-guestbook/frontend/src/main/java/cloudcode/guestbook/frontend/FrontendController.java
+++ b/java/java-guestbook/frontend/src/main/java/cloudcode/guestbook/frontend/FrontendController.java
@@ -31,9 +31,15 @@ public class FrontendController {
     @GetMapping("/")
     public final String main(final Model model) {
         RestTemplate restTemplate = new RestTemplate();
-        GuestBookEntry[] response = restTemplate.getForObject(backendUri,
+        try {
+            GuestBookEntry[] response = restTemplate.getForObject(backendUri,
             GuestBookEntry[].class);
-        model.addAttribute("messages", response);
+            model.addAttribute("messages", response);
+        } catch(Exception e) {
+            System.out.println("Error retrieving messages from backend.");
+            model.addAttribute("noBackend", true);
+        }
+
         return "home";
     }
 
@@ -53,7 +59,11 @@ public class FrontendController {
         HttpEntity<GuestBookEntry> httpEntity =
             new HttpEntity<GuestBookEntry>(formMessage, httpHeaders);
         RestTemplate restTemplate = new RestTemplate();
-        restTemplate.postForObject(url, httpEntity, String.class);
+        try {
+            restTemplate.postForObject(url, httpEntity, String.class);
+        } catch(Exception e) {
+            System.out.println("Error posting message to backend.");
+        }
 
         return "redirect:/";
     }

--- a/java/java-guestbook/frontend/src/main/java/cloudcode/guestbook/frontend/FrontendController.java
+++ b/java/java-guestbook/frontend/src/main/java/cloudcode/guestbook/frontend/FrontendController.java
@@ -36,6 +36,7 @@ public class FrontendController {
             GuestBookEntry[].class);
             model.addAttribute("messages", response);
         } catch(Exception e) {
+            e.printStackTrace();
             System.out.println("Error retrieving messages from backend.");
             model.addAttribute("noBackend", true);
         }
@@ -62,6 +63,7 @@ public class FrontendController {
         try {
             restTemplate.postForObject(url, httpEntity, String.class);
         } catch(Exception e) {
+            e.printStackTrace();
             System.out.println("Error posting message to backend.");
         }
 

--- a/java/java-guestbook/frontend/src/main/resources/templates/home.html
+++ b/java/java-guestbook/frontend/src/main/resources/templates/home.html
@@ -41,6 +41,10 @@
             <button type="submit" class="btn btn-primary mb-2">Post to Guestbook</button>
         </form>
 
+        <div class="alert alert-warning" role="alert" th:if="${#bools.isTrue(noBackend)}">
+            Warning: Backend service is not connected. Some features of Guestbook won't work.
+        </div>
+
         <div class="card my-3 col-12" th:each="m : ${messages}">
             <div class="card-body">
                 <h5 class="card-title" th:text="${m.Author}">Author</h5>


### PR DESCRIPTION
If the frontend receives no response from the backend, a warning message will appear.

(This warning message is also displayed when both services are deployed, if the frontend is accessed before the backend has finished deploying.)
<img width="940" alt="java-guestbook-frontend" src="https://user-images.githubusercontent.com/38271546/141177358-a6224329-3eb7-4cae-8f24-2841b9fc698a.png">

