### PR TITLE
Add v1 to baseBranches for renovate-bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "baseBranches": [
+    "v1"
+  ],
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
This will cause renovate-bot to create dependency PRs against the `v1` branch.

This can be reverted once `v1` is set as the default branch.