### PR TITLE
FIX - Set node for guestbook backend to be 17.4.0

### DIFF
--- a/nodejs/nodejs-guestbook/src/backend/Dockerfile
+++ b/nodejs/nodejs-guestbook/src/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use base node 12-slim image from Docker hub
-FROM node:17-slim
+FROM node:17.4.0-slim
 
 WORKDIR /backend
 


### PR DESCRIPTION
Node 17.5.0 broke the guestbook sample due to this bug: https://github.com/Automattic/mongoose/issues/11377