### PR TITLE
Update image links to point to correct location

### DIFF
--- a/dotnet/dotnet-cloud-run-hello-world/.readmes/vscode/README.md
+++ b/dotnet/dotnet-cloud-run-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps

--- a/golang/go-cloud-run-hello-world/.readmes/vscode/README.md
+++ b/golang/go-cloud-run-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps

--- a/java/java-cloud-run-hello-world/.readmes/vscode/README.md
+++ b/java/java-cloud-run-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps

--- a/nodejs/nodejs-cloud-run-hello-world/.readmes/vscode/README.md
+++ b/nodejs/nodejs-cloud-run-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps

--- a/python/cloud-run-django-hello-world/.readmes/vscode/README.md
+++ b/python/cloud-run-django-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps

--- a/python/cloud-run-python-hello-world/.readmes/vscode/README.md
+++ b/python/cloud-run-python-hello-world/.readmes/vscode/README.md
@@ -15,15 +15,15 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 ### Run the app locally with the Cloud Run Emulator
 1. Click on the Cloud Code status bar and select 'Run on Cloud Run Emulator'.  
-![image](./img/status-bar.png)
+![image](../../img/status-bar.png)
 
 2. Use the Cloud Run Emulator dialog to specify your [builder option](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app#deploying_a_cloud_run_service?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
-![image](./img/build-config.png)
+![image](../../img/build-config.png)
 
 3. Click ‘Run’. Cloud Code begins building your image.
 
 4. View the build progress in the OUTPUT window. Once the build has finished, click on the URL in the OUTPUT window to view your live application.  
-![image](./img/cloud-run-url.png)
+![image](../../img/cloud-run-url.png)
 
 5. To stop the application, click the stop icon on the Debug Toolbar.
 
@@ -34,12 +34,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. If prompted, login to your Google Cloud account and set your project.
 
 3. Use the Deploy to Cloud Run dialog to configure your deploy settings. For more information on the configuration options available, see [Deploying a Cloud Run app](https://cloud.google.com/code/docs/vscode/deploying-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
-![image](./img/deploy-build-config.png)
+![image](../../img/deploy-build-config.png)
 
 4. Click 'Deploy'. Cloud Code now builds your image, pushes it to the container registry, and deploys your service to Cloud Run.
 
 5. View your live service by clicking on the URL displayed at the top of the 'Deploy to Cloud Run' dialog.  
-![image](./img/cloud-run-deployed-url.png)
+![image](../../img/cloud-run-deployed-url.png)
 
 ---
 ## Next steps


### PR DESCRIPTION
Currently, when Cloud Run samples are checked out via Cloud Code for VS Code, they open a preview of `.readmes/vscode/README.md`. Unfortunately, the images in this file don't load, and this leads to users seeing broken image links. This PR updates the image file paths so that viewing them in VS Code works.

Before:
![image](https://user-images.githubusercontent.com/22482315/158275170-56aa5168-bbcf-4afd-a136-fd6c2d6345dc.png)

After: 
![image](https://user-images.githubusercontent.com/22482315/158275207-accc43c2-61ac-4f66-ac23-e9c365ef8008.png)

I tried to follow the same logic seen on the Kubernetes versions of these READMEs.