### PR TITLE
fix(docs): IntelliJ READMEs section links

### DIFF
--- a/dotnet/dotnet-cloud-run-hello-world/.readmes/intellij/README.md
+++ b/dotnet/dotnet-cloud-run-hello-world/.readmes/intellij/README.md
@@ -13,11 +13,11 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
@@ -25,7 +25,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/dotnet/dotnet-guestbook/.readmes/intellij/README.md
+++ b/dotnet/dotnet-guestbook/.readmes/intellij/README.md
@@ -20,11 +20,14 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
+
 - `skaffold.yaml` - A schema file that serves as an entry point for all Skaffold modules in the app
 - `src/frontend/` - Guestbook frontend service, containing the following config files:
   - `skaffold.yaml` - A schema file that defines the frontend Skaffold module ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
@@ -38,7 +41,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+<h3 id="skaffold-modules"> Skaffold modules </h3>
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -46,11 +50,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   Guestbook runs both the frontend and backend modules by default. To run a single module, follow the steps in the section [Run individual services with Skaffold modules](#run-individual-services-with-skaffold-modules). 
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -62,7 +67,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -71,9 +77,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -91,7 +97,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -102,7 +108,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -119,7 +125,7 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -136,7 +142,8 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -147,7 +154,7 @@ For more info on how to use Skaffold modules, see the [Skaffold documentation](h
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -159,7 +166,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/dotnet/dotnet-hello-world/.readmes/intellij/README.md
+++ b/dotnet/dotnet-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'dotnet-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -85,7 +89,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -96,7 +101,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -108,7 +113,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/golang/go-cloud-run-hello-world/.readmes/intellij/README.md
+++ b/golang/go-cloud-run-hello-world/.readmes/intellij/README.md
@@ -13,19 +13,20 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
-1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
+1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
 
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/golang/go-guestbook/.readmes/intellij/README.md
+++ b/golang/go-guestbook/.readmes/intellij/README.md
@@ -20,11 +20,14 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
+
 - `skaffold.yaml` - A schema file that serves as an entry point for all Skaffold modules in the app
 - `src/frontend/` - Guestbook frontend service, containing the following config files:
   - `skaffold.yaml` - A schema file that defines the frontend Skaffold module ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
@@ -38,7 +41,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+<h3 id="skaffold-modules"> Skaffold modules </h3>
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -46,11 +50,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   Guestbook runs both the frontend and backend modules by default. To run a single module, follow the steps in the section [Run individual services with Skaffold modules](#run-individual-services-with-skaffold-modules). 
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -62,7 +67,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -71,9 +77,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -91,7 +97,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -102,7 +108,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -119,7 +125,7 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -136,7 +142,8 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -147,7 +154,7 @@ For more info on how to use Skaffold modules, see the [Skaffold documentation](h
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -159,7 +166,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/golang/go-hello-world/.readmes/intellij/README.md
+++ b/golang/go-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'go-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -84,9 +88,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 
-
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -97,7 +101,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -109,7 +113,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ---
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/java/java-cloud-run-hello-world/.readmes/intellij/README.md
+++ b/java/java-cloud-run-hello-world/.readmes/intellij/README.md
@@ -13,19 +13,20 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
-1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
+1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
 
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/java/java-guestbook/.readmes/intellij/README.md
+++ b/java/java-guestbook/.readmes/intellij/README.md
@@ -20,11 +20,14 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
+
 - `skaffold.yaml` - A schema file that serves as an entry point for all Skaffold modules in the app
 - `src/frontend/` - Guestbook frontend service, containing the following config files:
   - `skaffold.yaml` - A schema file that defines the frontend Skaffold module ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
@@ -38,7 +41,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+<h3 id="skaffold-modules"> Skaffold modules </h3>
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -46,11 +50,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   Guestbook runs both the frontend and backend modules by default. To run a single module, follow the steps in the section [Run individual services with Skaffold modules](#run-individual-services-with-skaffold-modules). 
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -62,7 +67,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -71,9 +77,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -91,7 +97,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -102,7 +108,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -119,7 +125,7 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -136,7 +142,8 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -147,7 +154,7 @@ For more info on how to use Skaffold modules, see the [Skaffold documentation](h
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -159,7 +166,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/java/java-hello-world/.readmes/intellij/README.md
+++ b/java/java-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'java-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -86,7 +90,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -97,7 +102,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -109,7 +114,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ---
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/nodejs/nodejs-cloud-run-hello-world/.readmes/intellij/README.md
+++ b/nodejs/nodejs-cloud-run-hello-world/.readmes/intellij/README.md
@@ -13,19 +13,20 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
-1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
+1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
 
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/nodejs/nodejs-guestbook/.readmes/intellij/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/intellij/README.md
@@ -20,11 +20,14 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
+
 - `skaffold.yaml` - A schema file that serves as an entry point for all Skaffold modules in the app
 - `src/frontend/` - Guestbook frontend service, containing the following config files:
   - `skaffold.yaml` - A schema file that defines the frontend Skaffold module ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
@@ -38,7 +41,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+<h3 id="skaffold-modules"> Skaffold modules </h3>
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -46,11 +50,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   Guestbook runs both the frontend and backend modules by default. To run a single module, follow the steps in the section [Run individual services with Skaffold modules](#run-individual-services-with-skaffold-modules). 
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -62,7 +67,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -71,9 +77,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -91,7 +97,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -102,7 +108,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -119,7 +125,7 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -136,7 +142,8 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -147,7 +154,7 @@ For more info on how to use Skaffold modules, see the [Skaffold documentation](h
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -159,7 +166,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/nodejs/nodejs-hello-world/.readmes/intellij/README.md
+++ b/nodejs/nodejs-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'nodejs-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -86,7 +90,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -97,7 +102,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -109,7 +114,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ---
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/cloud-run-django-hello-world/.readmes/intellij/README.md
+++ b/python/cloud-run-django-hello-world/.readmes/intellij/README.md
@@ -13,11 +13,11 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
@@ -25,7 +25,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/cloud-run-python-hello-world/.readmes/intellij/README.md
+++ b/python/cloud-run-python-hello-world/.readmes/intellij/README.md
@@ -13,19 +13,20 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with the Cloud Run Emulator
+<h3 id="run-the-app-locally-with-the-cloud-run-emulator"> Run the app locally with the Cloud Run Emulator</h3>
 
-#### Define run configuration
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
-1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
+1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'. 
 ![image](./img/edit-config.png)
 
 2. Select 'Cloud Run: Run Locally' and specify your [builder option](https://cloud.google.com/code/docs/intellij/developing-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-). Cloud Code supports Docker, Jib, and Buildpacks. See the skaffold documentation on [builders](https://skaffold.dev/docs/pipeline-stages/builders/) for more information about build artifact types.  
 ![image](./img/local-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Run Locally'. Click the run icon.  
 ![image](./img/config-run-locally.png)
 
@@ -33,8 +34,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 
-### Deploy to Cloud Run
-#### Define run configuration
+<h3 id="deploy-to-cloud-run"> Deploy to Cloud Run</h3>
+<h4 id="define-run-configuration"> Define run configuration</h4>
 
 1. Click the Run/Debug configurations dropdown on the top taskbar and select 'Edit Configurations'.  
 ![image](./img/edit-config.png)
@@ -42,7 +43,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 2. Select 'Cloud Run: Deploy'. Set your Google Cloud project ID, logging into your Google account if prompted. For more information on configuration settings, see [Defining your run configuration](https://cloud.google.com/code/docs/intellij/deploying-a-cloud-run-app#defining_your_run_configuration?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-).  
 ![image](./img/deploy-build-config.png)
 
-#### Run the application
+<h4 id="run-the-application"> Run the application</h4>
+
 1. Click the Run/Debug configurations dropdown and select 'Cloud Run: Deploy'. Click the run icon.  
 ![image](./img/config-deploy.png)
 
@@ -50,7 +52,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 ![image](./img/local-success.png)
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps</h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/debugging-a-cloud-run-app?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Nagivate the [Cloud Run Explorer](https://cloud.google.com/code/docs/intellij/cloud-run-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * View [streaming logs](https://cloud.google.com/code/docs/intellij/viewing-cloud-run-logs?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
@@ -60,7 +63,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research</h2>
 
 We want to hear your feedback!
 
@@ -72,7 +75,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support</h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/django/python-guestbook/.readmes/intellij/README.md
+++ b/python/django/python-guestbook/.readmes/intellij/README.md
@@ -16,11 +16,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -32,7 +33,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -41,9 +43,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -61,7 +63,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -72,7 +74,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -83,7 +86,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -99,7 +102,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/django/python-hello-world/.readmes/intellij/README.md
+++ b/python/django/python-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'python-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -86,7 +90,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -97,7 +102,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -109,7 +114,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ---
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/python-guestbook/.readmes/intellij/README.md
+++ b/python/python-guestbook/.readmes/intellij/README.md
@@ -20,11 +20,14 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
+
 - `skaffold.yaml` - A schema file that serves as an entry point for all Skaffold modules in the app
 - `src/frontend/` - Guestbook frontend service, containing the following config files:
   - `skaffold.yaml` - A schema file that defines the frontend Skaffold module ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
@@ -38,7 +41,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   - `kubernetes-manifests/guestbook-mongodb.deployment.yaml` - deploys a pod containing a MongoDB instance
   - `kubernetes-manifests/guestbook-mongodb.service.yaml` - exposes the MongoDB service on an internal IP in the cluster
 
-  ### Skaffold modules
+<h3 id="skaffold-modules"> Skaffold modules </h3>
+
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -46,11 +50,12 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
   Guestbook runs both the frontend and backend modules by default. To run a single module, follow the steps in the section [Run individual services with Skaffold modules](#run-individual-services-with-skaffold-modules). 
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
    ![image](../../img/edit-configurations.png)
 
@@ -62,7 +67,8 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -71,9 +77,9 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -91,7 +97,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -102,7 +108,7 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -119,7 +125,7 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-### Run individual services with Skaffold modules
+<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
 
 1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
 
@@ -136,7 +142,8 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -147,7 +154,7 @@ For more info on how to use Skaffold modules, see the [Skaffold documentation](h
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -159,7 +166,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ----
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 

--- a/python/python-hello-world/.readmes/intellij/README.md
+++ b/python/python-hello-world/.readmes/intellij/README.md
@@ -16,11 +16,13 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 * [Getting support](#getting-support)
 
 ---
-## What's in this sample
-### Kubernetes architecture
+<h2 id="whats-in-this-sample"> What's in this sample </h2>
+
+<h3 id="kubernetes-architecture"> Kubernetes architecture </h3>
+
 ![Kubernetes Architecture Diagram](../../img/diagram.png)
 
-### Directory contents
+<h3 id="directory-contents"> Directory contents </h3>
 
 - `skaffold.yaml` - A schema file that defines skaffold configurations ([skaffold.yaml reference](https://skaffold.dev/docs/references/yaml/))
 - `kubernetes-manifests/` - Contains Kubernetes YAML files for the Guestbook services and deployments, including:
@@ -29,11 +31,12 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
   - `hello.service.yaml` - creates a load balancer and exposes the 'python-hello-world' service on an external IP in the cluster
 
 ---
-## Getting Started
+<h2 id="getting-started"> Getting Started </h2>
 
-### Run the app locally with minikube
+<h3 id="run-the-app-locally-with-minikube"> Run the app locally with minikube </h3>
 
-#### Edit run configuration
+<h4 id="edit-run-configuration"> Edit run configuration </h4>
+
 1. Click the configuration dropdown in the top taskbar and then click **Edit Configurations**.
 ![image](../../img/edit-configurations.png)
 
@@ -45,7 +48,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 4. Click **OK** to save your configuration.
 
 
-#### Run the app on minikube
+<h4 id="run-the-app-on-minikube"> Run the app on minikube </h4>
+
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. Cloud Code runs your app in a local [minikube](ttps://minikube.sigs.k8s.io/docs/start/) cluster.
 
 2. View the build process in the output window. When the deployment is successful, you're notified that new service URLs are available. Click the Service URLs tab to view the URL(s), then click the URL link to open your browser with your running application.  
@@ -54,9 +58,9 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 3. To stop the application, click the stop icon next to the configuration dropdown.
 
 ---
-### Run the app remotely on Google Kubernetes Engine
+<h3 id="run-the-app-remotely-with-google-kubernetes-engine"> Run the app remotely with Google Kubernetes Engine </h3>
 
-#### Set up a GKE cluster
+<h4 id="set-up-a-gke-cluster"> Set up a GKE cluster </h4>
 
 1. Navigate to the Kubernetes Explorer from the right side panel, or by going to **Tools > Cloud Code > Kubernetes > View Cluster Explorer**. 
 
@@ -74,7 +78,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 6. Your new cluster will be set as the current context by default. To switch contexts, right click on a different cluster in the Cluster Explorer and select **Set as Current Context**. 
 
-#### Deploy app to GKE
+<h4 id="deploy-app-to-gke"> Deploy app to GKE </h4>
 
 1. Select **Develop on Kubernetes** from the configuration dropdown and click the run icon. 
 
@@ -86,7 +90,8 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 
 
 ---
-## Next steps
+<h2 id="next-steps"> Next steps </h2>
+
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code
 * Navigate the [Kubernetes Engine Explorer](https://cloud.google.com/code/docs/intellij/using-the-kubernetes-explorer?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-)
 * Learn how to [edit YAML files](https://cloud.google.com/code/docs/intellij/yaml-editing?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) to deploy your Kubernetes app
@@ -97,7 +102,7 @@ This "Hello World" sample demonstrates how to deploy a simple "Hello World" appl
 For more Cloud Code tutorials and resources, check out [Awesome Cloud Code](https://github.com/russwolf/awesome-cloudclode)!
 
 ---
-## Sign up for User Research
+<h2 id="sign-up-for-user-research"> Sign up for User Research </h2>
 
 We want to hear your feedback!
 
@@ -109,7 +114,7 @@ If you’re invited to join a study, you may try out a new product or tell us wh
 
 ---
 
-## Getting support
+<h2 id="getting-support"> Getting support </h2>
 
 If you encounter any bugs, confusing commands, or unclear documentation, you can file your feedback [directly on GitHub](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues).
 


### PR DESCRIPTION
Replaces standard Markdown anchors (`## Section`) with html-style headers (`<h2 id="section"> Section </h2>`)

When viewing files in the Markdown Preview renderer in IntelliJ (and other JetBrains IDEs), the standard Markdown reference link format doesn't work. Links need to be styled like HTML headers. 

Fixes #799 