### PR TITLE
fix(docs): cleanup READMEs

### DIFF
--- a/dotnet/dotnet-guestbook/.readmes/intellij/README.md
+++ b/dotnet/dotnet-guestbook/.readmes/intellij/README.md
@@ -125,23 +125,6 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
-
-1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
-
-2. Select skaffold.yaml.
-
-3. Choose **Build and deploy with** and select either the frontend or backend module. This tells Cloud Code to deploy only the selected service. You can select more than one module to deploy.
-
-Note: The complete Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy one service to demonstrate running individual modules.
-
-4. You can now run the selected module by deploying it to [minikube](#run-the-app-on-minikube) or [GKE](#deploy-app-to-gke). 
-
-You can see how the Guestbook modules are defined by checking out the frontend's [skaffold.yaml](../../src/frontend/skaffold.yaml) and the backend's [skaffold.yaml](../../src/backend/skaffold.yaml).
-
-For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
-
----
 <h2 id="next-steps"> Next steps </h2>
 
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code

--- a/dotnet/dotnet-guestbook/.readmes/vscode/README.md
+++ b/dotnet/dotnet-guestbook/.readmes/vscode/README.md
@@ -37,8 +37,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 ### Skaffold modules
 
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
-
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -95,8 +93,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 If you created a GKE cluster for this tutorial, be sure to delete your cluster to avoid incurring charges.
 
 ### Run individual services with Skaffold modules
-
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/golang/go-guestbook/.readmes/intellij/README.md
+++ b/golang/go-guestbook/.readmes/intellij/README.md
@@ -125,23 +125,6 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
-
-1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
-
-2. Select skaffold.yaml.
-
-3. Choose **Build and deploy with** and select either the frontend or backend module. This tells Cloud Code to deploy only the selected service. You can select more than one module to deploy.
-
-Note: The complete Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy one service to demonstrate running individual modules.
-
-4. You can now run the selected module by deploying it to [minikube](#run-the-app-on-minikube) or [GKE](#deploy-app-to-gke). 
-
-You can see how the Guestbook modules are defined by checking out the frontend's [skaffold.yaml](../../src/frontend/skaffold.yaml) and the backend's [skaffold.yaml](../../src/backend/skaffold.yaml).
-
-For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
-
----
 <h2 id="next-steps"> Next steps </h2>
 
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code

--- a/golang/go-guestbook/.readmes/vscode/README.md
+++ b/golang/go-guestbook/.readmes/vscode/README.md
@@ -37,8 +37,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 ### Skaffold modules
 
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
-
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -95,8 +93,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 If you created a GKE cluster for this tutorial, be sure to delete your cluster to avoid incurring charges.
 
 ### Run individual services with Skaffold modules
-
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/java/java-guestbook/.readmes/intellij/README.md
+++ b/java/java-guestbook/.readmes/intellij/README.md
@@ -125,23 +125,6 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
-
-1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
-
-2. Select skaffold.yaml.
-
-3. Choose **Build and deploy with** and select either the frontend or backend module. This tells Cloud Code to deploy only the selected service. You can select more than one module to deploy.
-
-Note: The complete Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy one service to demonstrate running individual modules.
-
-4. You can now run the selected module by deploying it to [minikube](#run-the-app-on-minikube) or [GKE](#deploy-app-to-gke). 
-
-You can see how the Guestbook modules are defined by checking out the frontend's [skaffold.yaml](../../src/frontend/skaffold.yaml) and the backend's [skaffold.yaml](../../src/backend/skaffold.yaml).
-
-For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
-
----
 <h2 id="next-steps"> Next steps </h2>
 
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code

--- a/java/java-guestbook/.readmes/vscode/README.md
+++ b/java/java-guestbook/.readmes/vscode/README.md
@@ -37,8 +37,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 ### Skaffold modules
 
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
-
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -95,8 +93,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 If you created a GKE cluster for this tutorial, be sure to delete your cluster to avoid incurring charges.
 
 ### Run individual services with Skaffold modules
-
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/nodejs/nodejs-guestbook/.readmes/intellij/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/intellij/README.md
@@ -125,23 +125,6 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
-
-1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
-
-2. Select skaffold.yaml.
-
-3. Choose **Build and deploy with** and select either the frontend or backend module. This tells Cloud Code to deploy only the selected service. You can select more than one module to deploy.
-
-Note: The complete Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy one service to demonstrate running individual modules.
-
-4. You can now run the selected module by deploying it to [minikube](#run-the-app-on-minikube) or [GKE](#deploy-app-to-gke). 
-
-You can see how the Guestbook modules are defined by checking out the frontend's [skaffold.yaml](../../src/frontend/skaffold.yaml) and the backend's [skaffold.yaml](../../src/backend/skaffold.yaml).
-
-For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
-
----
 <h2 id="next-steps"> Next steps </h2>
 
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code

--- a/nodejs/nodejs-guestbook/.readmes/vscode/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/vscode/README.md
@@ -37,8 +37,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 ### Skaffold modules
 
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
-
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -95,8 +93,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 If you created a GKE cluster for this tutorial, be sure to delete your cluster to avoid incurring charges.
 
 ### Run individual services with Skaffold modules
-
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 

--- a/python/python-guestbook/.readmes/intellij/README.md
+++ b/python/python-guestbook/.readmes/intellij/README.md
@@ -125,23 +125,6 @@ You can see how the Guestbook modules are defined by checking out the frontend's
 For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
 
 ---
-<h3 id="run-individual-services-with-skaffold-modules"> Run individual services with Skaffold modules </h3>
-
-1. Go to **Run** > **Edit configurations** and open the **Build / Deploy** tab.
-
-2. Select skaffold.yaml.
-
-3. Choose **Build and deploy with** and select either the frontend or backend module. This tells Cloud Code to deploy only the selected service. You can select more than one module to deploy.
-
-Note: The complete Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy one service to demonstrate running individual modules.
-
-4. You can now run the selected module by deploying it to [minikube](#run-the-app-on-minikube) or [GKE](#deploy-app-to-gke). 
-
-You can see how the Guestbook modules are defined by checking out the frontend's [skaffold.yaml](../../src/frontend/skaffold.yaml) and the backend's [skaffold.yaml](../../src/backend/skaffold.yaml).
-
-For more info on how to use Skaffold modules, see the [Skaffold documentation](https://skaffold.dev/docs/design/config/#multiple-configuration-support).
-
----
 <h2 id="next-steps"> Next steps </h2>
 
 * Try [debugging your app](https://cloud.google.com/code/docs/intellij/kubernetes-debugging?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) using Cloud Code

--- a/python/python-guestbook/.readmes/vscode/README.md
+++ b/python/python-guestbook/.readmes/vscode/README.md
@@ -37,8 +37,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 
 ### Skaffold modules
 
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
-
   The Guestbook app uses Skaffold configuration dependencies, or **modules**, to define individual configurations for the frontend and backend services. Each module constitutes a single build-test-deploy pipeline that can be executed in isolation or as a dependency of another module. 
 
   Cloud Code enables iterative development and debugging on a single module or a subset of many modules, and makes editing the skaffold.yaml file configuration with modules easier. Underlying Skaffold takes care of module dependencies and their order of deployment.
@@ -95,8 +93,6 @@ The Guestbook sample demonstrates how to deploy a Kubernetes application with a 
 If you created a GKE cluster for this tutorial, be sure to delete your cluster to avoid incurring charges.
 
 ### Run individual services with Skaffold modules
-
->  Note: This feature is currently only available on the [insiders release](https://cloud.google.com/code/docs/vscode/insiders?utm_source=ext&utm_medium=partner&utm_campaign=CDR_kri_gcp_cloudcodereadmes_012521&utm_content=-) of Cloud Code. To get the latest pre-release build of Cloud Code, follow the instructions on [Installing Insiders builds](https://cloud.google.com/code/docs/vscode/insiders#get).
 
 The Guestbook app needs both services deployed to function properly, but for this tutorial we'll deploy only the frontend service to demonstrate running individual modules.
 


### PR DESCRIPTION
- Removes duplicate section on Skaffold Modules from IntelliJ READMEs for .NET, Go, Java, Node.js, and Python Guestbooks.
- Removes note advising that running Skaffold Modules is only available with the insiders build of Cloud Code from VS Code READMEs for .NET, Go, Java, Node.js, and Python Guestbooks. Skaffold Module functionality was released in Cloud Code for VS Code [version v1.17.0](https://github.com/GoogleCloudPlatform/cloud-code-vscode/releases/tag/v1.17.0).