### PR TITLE
Fixing URLs for Skaffold modules on readme files.

### DIFF
--- a/java/java-guestbook/.readmes/vscode/README.md
+++ b/java/java-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/src/main/resources/templates/home.html](../../frontend/src/main/resources/templates/home.html).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 

--- a/nodejs/nodejs-guestbook/.readmes/vscode/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/views/home.pug](../../src/frontend/views/home.pug).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 


### PR DESCRIPTION
The VS Code Readme for Java and Node.js have Stale links under the skaffold modules section. Fixing them to ensure the demo for skaffold modules can be used by developers trying the samples.