### PR TITLE
Fix readme for guestbook sample skaffold modules section  

### DIFF
--- a/golang/go-guestbook/.readmes/vscode/README.md
+++ b/golang/go-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/templates/home.tpl](../../src/frontend/templates/home.tpl).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 

--- a/java/java-guestbook/.readmes/vscode/README.md
+++ b/java/java-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/src/main/resources/templates/home.html](../../frontend/src/main/resources/templates/home.html).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 

--- a/nodejs/nodejs-guestbook/.readmes/vscode/README.md
+++ b/nodejs/nodejs-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/views/home.pug](../../src/frontend/views/home.pug).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 

--- a/python/python-guestbook/.readmes/vscode/README.md
+++ b/python/python-guestbook/.readmes/vscode/README.md
@@ -115,7 +115,7 @@ This tells Cloud Code to build and deploy only the frontend module.
 4. View the build's progress in the OUTPUT window. Once the build has finished, you can view the deployed frontend module by clicking on the URL in the OUTPUT window.
 
 5. Now, you can quickly iterate on the frontend service without having to rebuild and deploy the entire app for every change.    
-  a. Navigate to [frontend/Views/Home/Index.cshtml](../../src/frontend/Views/Home/Index.cshtml).  
+  a. Navigate to [frontend/templates/home.html](../../src/frontend/templates/home.html).  
   b. Make a change to the file (e.g. "My Guestbook" > "My Frontend Guestbook").  
   c. The frontend service will rebuild and you can see your changes in the deployed frontend service.  
 


### PR DESCRIPTION
Updated readme files for Python, Go, Java and Node.js to point to the correct file path 