### PR TITLE
Remove mongo reconnectTries option

### DIFF
--- a/nodejs/nodejs-guestbook/src/backend/routes/messages.js
+++ b/nodejs/nodejs-guestbook/src/backend/routes/messages.js
@@ -18,7 +18,6 @@ const connectToMongoDB = async () => {
     await mongoose.connect(mongoURI, {
         useNewUrlParser: true,
         connectTimeoutMS: 2000,
-        reconnectTries: 5,
         useUnifiedTopology: true
     })
 };


### PR DESCRIPTION
Avoid this error currently affecting consumers of this sample:

```
[backend]MongoParseError: option reconnecttries is not supported
[backend]    at parseOptions (/backend/node_modules/mongoose/node_modules/mongodb/lib/connection_string.js:289:15)
[backend]    at new MongoClient (/backend/node_modules/mongoose/node_modules/mongodb/lib/mongo_client.js:62:63)
[backend]    at /backend/node_modules/mongoose/lib/connection.js:784:16
[backend]    at new Promise (<anonymous>)
[backend]    at Connection.openUri (/backend/node_modules/mongoose/lib/connection.js:781:19)
[backend]    at /backend/node_modules/mongoose/lib/index.js:341:10
[backend]    at /backend/node_modules/mongoose/lib/helpers/promiseOrCallback.js:32:5
[backend]    at new Promise (<anonymous>)
[backend]    at promiseOrCallback (/backend/node_modules/mongoose/lib/helpers/promiseOrCallback.js:31:10)
[backend]    at Mongoose._promiseOrCallback (/backend/node_modules/mongoose/lib/index.js:1141:10)
```