### PR TITLE
fix: nodejs-guestbook buildpacks builder not working

### DIFF
--- a/nodejs/nodejs-guestbook/src/backend/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/src/backend/skaffold.yaml
@@ -25,4 +25,5 @@ profiles:
       context: .
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
-        
+        env:
+        - GOOGLE_RUNTIME_VERSION=16.16.0

--- a/nodejs/nodejs-guestbook/src/frontend/skaffold.yaml
+++ b/nodejs/nodejs-guestbook/src/frontend/skaffold.yaml
@@ -33,4 +33,5 @@ profiles:
       context: .
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
-        
+        env:
+        - GOOGLE_RUNTIME_VERSION=16.16.0


### PR DESCRIPTION
running `skaffold build -p buildpacks` in the `nodejs/nodejs-guestbook` app from an M1 Mac always results in the following error:
```
...

[builder] npm ERR! A complete log of this run can be found in:
[builder] npm ERR!     /home/cnb/.npm/_logs/2022-07-30T07_44_41_031Z-debug-0.log
[builder] --------------------------------------------------------------------------------
[builder] Sorry your project couldn't be built.
[builder] Our documentation explains ways to configure Buildpacks to better recognise your project:
[builder]  -> https://github.com/GoogleCloudPlatform/buildpacks/blob/main/README.md
[builder] If you think you've found an issue, please report it:
[builder]  -> https://github.com/GoogleCloudPlatform/buildpacks/issues/new
[builder] --------------------------------------------------------------------------------
[builder] ERROR: failed to build: exit status 1
```
Setting the nodejs version explicitly according to https://github.com/GoogleCloudPlatform/buildpacks/issues/215 fixes the issue.