### PR TITLE
Revert "chore(deps): update python docker tag to v3.11"

### DIFF
--- a/python/cloud-run-django-hello-world/Dockerfile
+++ b/python/cloud-run-django-hello-world/Dockerfile
@@ -1,5 +1,5 @@
 # Python image to use.
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/cloud-run-python-hello-world/Dockerfile
+++ b/python/cloud-run-python-hello-world/Dockerfile
@@ -1,5 +1,5 @@
 # Python image to use.
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/django/python-guestbook/src/Dockerfile
+++ b/python/django/python-guestbook/src/Dockerfile
@@ -1,5 +1,5 @@
 # Use base Python image from Docker Hub
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/django/python-hello-world/src/Dockerfile
+++ b/python/django/python-hello-world/src/Dockerfile
@@ -1,5 +1,5 @@
 # Python image to use.
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/python-guestbook/src/backend/Dockerfile
+++ b/python/python-guestbook/src/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use base Python image from Docker Hub
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/python-guestbook/src/frontend/Dockerfile
+++ b/python/python-guestbook/src/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Use base Python image from Docker Hub
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app

--- a/python/python-hello-world/src/Dockerfile
+++ b/python/python-hello-world/src/Dockerfile
@@ -1,5 +1,5 @@
 # Python image to use.
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
This reverts commit ee092e112bc56c970c5b52a5364c386d7f007c29.

The upgrade to 3.11 breaks debugging in Cloud Code with the following error:

```
      > [cloud-run-python-hello-world-7d675c67f5-hjhf9 cloud-run-python-hello-world-container] time="2022-11-18T22:18:45Z" level=warning msg="Debugging support for Python 3.11 not found: may require manually installing \"debugpy\""
      > [cloud-run-python-hello-world-7d675c67f5-hjhf9 cloud-run-python-hello-world-container] /usr/local/bin/python: No module named debugpy
      > [cloud-run-python-hello-world-7d675c67f5-hjhf9 cloud-run-python-hello-world-container] time="2022-11-18T22:18:45Z" level=fatal msg="error launching python debugging: exit status 1"
 - deployment/cloud-run-python-hello-world failed. Error: container cloud-run-python-hello-world-container terminated with exit code 1.
```