### PR TITLE
Upgrade the java-cloud-run-hello-world to the latest version of spring-cloud-gcp-dependencies

### DIFF
--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.6</version>
+    <version>3.0.2</version>
   </parent>
 
   <properties>
@@ -34,11 +34,11 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
+      <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -22,9 +22,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.cloud</groupId>
+        <groupId>com.google.cloud</groupId>
         <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>1.2.8.RELEASE</version>
+        <version>4.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -50,7 +50,7 @@
     </dependency>
     <!-- Starter for Stackriver Logging -->
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-logging</artifactId>
     </dependency>
     <dependency>

--- a/java/java-cloud-run-hello-world/pom.xml
+++ b/java/java-cloud-run-hello-world/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/java/java-cloud-run-hello-world/src/main/resources/logback-spring.xml
+++ b/java/java-cloud-run-hello-world/src/main/resources/logback-spring.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-  <include resource=
-    "org/springframework/cloud/gcp/logging/logback-json-appender.xml"/>
-  <root level="INFO">
-    <appender-ref ref="CONSOLE_JSON"/>
-  </root>
+    <include resource="org/springframework/cloud/gcp/logging/logback-json-appender.xml"/>
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE_JSON"/>
+    </root>
 </configuration>

--- a/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
+++ b/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
@@ -5,15 +5,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
+++ b/java/java-cloud-run-hello-world/src/test/java/cloudcode/helloworld/web/HelloWorldControllerIT.java
@@ -5,28 +5,34 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Integration test for local or remote service based on the env var
- * "SERVICE_URL". See java/CONTRIBUTING.MD for more information. 
+ * "SERVICE_URL". See java/CONTRIBUTING.MD for more information.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 public class HelloWorldControllerIT {
 
+  @LocalServerPort
+  private int randomServerPort;
   @Test
   public void respondsToHttpRequest() throws IOException {
-    String port = System.getenv("PORT");
+    String port = String.valueOf(randomServerPort);
     if (port == null || port == "") {
       port = "8080";
     }


### PR DESCRIPTION
On January 30th, a new version of spring-cloud-gcp, version 4.0.0, was released. This pull request aims to upgrade to this version and make any necessary changes to comply with breaking changes.

For instance, the groupId for spring-cloud-gcp-starter-logging has been changed and the logback-spring.xml file has been adjusted to follow the guidelines at https://logback.qos.ch/codes.html#appender_order to ensure the code works properly. Additionally, the tests have been updated to work with the new version.

P.S. Spring was upgraded too in this PR to work better with the new version of spring-cloud-gcp (https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html#getting-started):

![[spring-cloud-gcp compatibility with Spring Project Versions](https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html#compatibility-with-spring-project-versions)](https://user-images.githubusercontent.com/48111506/216207436-956c9dbe-a12e-4f35-9034-6332c1977231.png)
