### PR TITLE
Add dockerfile profile to java launch.config files to fix k8s deployments

### DIFF
--- a/java/java-guestbook/.vscode/launch.json
+++ b/java/java-guestbook/.vscode/launch.json
@@ -9,6 +9,7 @@
       "type": "cloudcode.kubernetes",
       "request": "launch",
       "skaffoldConfig": "${workspaceFolder}/skaffold.yaml",
+      "profile": "dockerfile",
       "watch": true,
       "cleanUp": true,
       "portForward": true

--- a/java/java-hello-world/.vscode/launch.json
+++ b/java/java-hello-world/.vscode/launch.json
@@ -9,9 +9,11 @@
         "type": "cloudcode.kubernetes",
         "request": "launch",
         "skaffoldConfig": "${workspaceFolder}/skaffold.yaml",
+        "profile": "dockerfile",
         "watch": true,
         "cleanUp": true,
-        "portForward": true
+        "portForward": true,
+        "imageRegistry": "gcr.io/cloud-code-vs-code"
       }
     ]
   }

--- a/java/java-hello-world/.vscode/launch.json
+++ b/java/java-hello-world/.vscode/launch.json
@@ -12,8 +12,7 @@
         "profile": "dockerfile",
         "watch": true,
         "cleanUp": true,
-        "portForward": true,
-        "imageRegistry": "gcr.io/cloud-code-vs-code"
+        "portForward": true
       }
     ]
   }


### PR DESCRIPTION
Currently, Cloud Code defaults to using cloudbuild if a user opens samples.workspace and tries to deploy the java samples to k8s due to maven changes (see: https://github.com/GoogleCloudPlatform/cloud-code-samples/pull/1207)