### PR TITLE
Set CGO_ENABLED=0 for distroless builds

### DIFF
--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
+RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/backend .
+RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/backend .
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/frontend .
+RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/frontend .
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -16,7 +16,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
+RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base


### PR DESCRIPTION
https://github.com/GoogleContainerTools/distroless/issues/1342 breaks go samples due to a mismatch of c library availability between distroless images and goland images. Setting CGO_ENABLED=0 bypasses the need for these libs.