### PR TITLE
Set CGO_ENABLED=0 for the whole build to be set on all go commands

### DIFF
--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.19 AS build
 
 WORKDIR /hello-world
+
+# Avoid dynamic linking of libc, since we are using a different deployment image
+# that might have a different version of libc.
 ENV CGO_ENABLED=0
 
 # Install dependencies in go.mod and go.sum
@@ -18,7 +21,7 @@ RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static-debian11
 
 # Definition of this variable is used by 'skaffold debug' to identify a golang binary.
 # Default behavior - a failure prints a stack trace for the current goroutine.

--- a/golang/go-cloud-run-hello-world/Dockerfile
+++ b/golang/go-cloud-run-hello-world/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.19 AS build
 
 WORKDIR /hello-world
+ENV CGO_ENABLED=0
 
 # Install dependencies in go.mod and go.sum
 COPY go.mod go.sum ./
@@ -14,7 +15,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.19 as build
 
 WORKDIR /app
+
+# Avoid dynamic linking of libc, since we are using a different deployment image
+# that might have a different version of libc.
 ENV CGO_ENABLED=0
 
 # Copy the go.mod and go.sum, download the dependencies
@@ -18,7 +21,7 @@ RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/backend .
 
 # Now create separate deployment image
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static-debian11
 
 # Definition of this variable is used by 'skaffold debug' to identify a golang binary.
 # Default behavior - a failure prints a stack trace for the current goroutine.

--- a/golang/go-guestbook/src/backend/Dockerfile
+++ b/golang/go-guestbook/src/backend/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.19 as build
 
 WORKDIR /app
+ENV CGO_ENABLED=0
 
 # Copy the go.mod and go.sum, download the dependencies
 COPY go.mod go.sum ./
@@ -14,7 +15,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/backend .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/backend .
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.19 as build
 
 WORKDIR /app
+
+# Avoid dynamic linking of libc, since we are using a different deployment image
+# that might have a different version of libc.
 ENV CGO_ENABLED=0
 
 # Copy the go.mod and go.sum, download the dependencies
@@ -18,7 +21,7 @@ RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/frontend .
 
 # Now create separate deployment image
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static-debian11
 
 # Definition of this variable is used by 'skaffold debug' to identify a golang binary.
 # Default behavior - a failure prints a stack trace for the current goroutine.

--- a/golang/go-guestbook/src/frontend/Dockerfile
+++ b/golang/go-guestbook/src/frontend/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.19 as build
 
 WORKDIR /app
+ENV CGO_ENABLED=0
 
 # Copy the go.mod and go.sum, download the dependencies
 COPY go.mod go.sum ./
@@ -14,7 +15,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/frontend .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app/frontend .
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -4,6 +4,7 @@
 FROM golang:1.19 as build
 
 WORKDIR /hello-world
+ENV CGO_ENABLED=0
 
 # Install dependencies in go.mod and go.sum
 COPY go.mod go.sum ./
@@ -16,7 +17,7 @@ COPY . ./
 # Skaffold passes in debug-oriented compiler flags
 ARG SKAFFOLD_GO_GCFLAGS
 RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
-RUN CGO_ENABLED=0 go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
 FROM gcr.io/distroless/base

--- a/golang/go-hello-world/Dockerfile
+++ b/golang/go-hello-world/Dockerfile
@@ -4,6 +4,9 @@
 FROM golang:1.19 as build
 
 WORKDIR /hello-world
+
+# Avoid dynamic linking of libc, since we are using a different deployment image
+# that might have a different version of libc.
 ENV CGO_ENABLED=0
 
 # Install dependencies in go.mod and go.sum
@@ -20,7 +23,7 @@ RUN echo "Go gcflags: ${SKAFFOLD_GO_GCFLAGS}"
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -mod=readonly -v -o /app
 
 # Now create separate deployment image
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static-debian11
 
 # Definition of this variable is used by 'skaffold debug' to identify a golang binary.
 # Default behavior - a failure prints a stack trace for the current goroutine.


### PR DESCRIPTION
After #1248, we are still seeing some breakages on the `go mod download`. This sets the variable for the whole build so any call to `go` will get the option.