### PR TITLE
fix: upgrade k8s cluster

### DIFF
--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -62,7 +62,6 @@ steps:
   - '-c'
   - |
     set -e
-
     # Testing connection
     chmod +x test_connection.sh
     ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)

--- a/cloudbuild.tmpl.yaml
+++ b/cloudbuild.tmpl.yaml
@@ -16,7 +16,7 @@ steps:
   args:
   - '-c'
   - |
-    # Builds java apps with dockerfile profile due to jib/skaffold community builder incompatibility 
+    # Builds java apps with dockerfile profile due to jib/skaffold community builder incompatibility
     if [ "${_LANG}" = "java" ]
     then
         skaffold run -p dockerfile -l $BUILD_ID -n $$TEST_NAMESPACE -d $$SKAFFOLD_DEFAULT_REPO
@@ -61,7 +61,7 @@ steps:
   args:
   - '-c'
   - |
-    set -e 
+    set -e
 
     # Testing connection
     chmod +x test_connection.sh
@@ -93,7 +93,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-$_LANG-$_APP
     - HELLO_WORLD_SERVICE=${_LANG}-${_APP}-external

--- a/dotnet/.ci/dotnet-hello-world.cloudbuild.yaml
+++ b/dotnet/.ci/dotnet-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-dotnet-hello-world
     - HELLO_WORLD_SERVICE=dotnet-hello-world-external

--- a/golang/.ci/go-hello-world.cloudbuild.yaml
+++ b/golang/.ci/go-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-go-hello-world
     - HELLO_WORLD_SERVICE=go-hello-world-external

--- a/java/.ci/java-hello-world.cloudbuild.yaml
+++ b/java/.ci/java-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-java-hello-world
     - HELLO_WORLD_SERVICE=java-hello-world-external

--- a/nodejs/.ci/nodejs-hello-world.cloudbuild.yaml
+++ b/nodejs/.ci/nodejs-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-nodejs-hello-world
     - HELLO_WORLD_SERVICE=nodejs-hello-world-external

--- a/python/.ci/django-hello-world.cloudbuild.yaml
+++ b/python/.ci/django-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-django-hello-world
     - HELLO_WORLD_SERVICE=django-python-hello-world-external

--- a/python/.ci/python-hello-world.cloudbuild.yaml
+++ b/python/.ci/python-hello-world.cloudbuild.yaml
@@ -46,7 +46,7 @@ steps:
     args:
     - '-c'
     - |
-      set -e 
+      set -e
       # Testing connection
       chmod +x test_connection.sh
       ./test_connection.sh -r 20 -i 3 -u http://$(cat _externalIP)
@@ -68,7 +68,7 @@ timeout: 2500s
 options:
     env:
     - CLOUDSDK_COMPUTE_ZONE=us-central1-a
-    - CLOUDSDK_CONTAINER_CLUSTER=staging
+    - CLOUDSDK_CONTAINER_CLUSTER=test-cluster
     - SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID
     - TEST_NAMESPACE=test-$BUILD_ID-python-hello-world
     - HELLO_WORLD_SERVICE=python-hello-world-external


### PR DESCRIPTION
This PR will update replace the test cluster running 1.24.14-gke.2700 with an updated cluster running 1.27.3-gke.100