### PR TITLE
Adding a profile that uses a service with internalload balancer for testing purposes in node example

### DIFF
--- a/golang/go-hello-world/kubernetes-manifests/hello.service.internal.yaml
+++ b/golang/go-hello-world/kubernetes-manifests/hello.service.internal.yaml
@@ -1,16 +1,18 @@
 # This Service manifest defines:
-# - a load balancer for pods matching label "app: node-hello-world"
-# - exposing the application to the public Internet (type:LoadBalancer)
+# - a load balancer for pods matching label "app: go-hello-world"
+# - NOT exposing the application to the public Internet (internal load balancer)
 # - routes port 80 of the load balancer to the port 8080 of the Pods.
 # Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
 apiVersion: v1
 kind: Service
 metadata:
-  name: nodejs-hello-world-external
+  name: go-hello-world-internal
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   selector:
-    app: nodejs-hello-world
+    app: go-hello-world
   ports:
   - name: http
     port: 80

--- a/golang/go-hello-world/skaffold.yaml
+++ b/golang/go-hello-world/skaffold.yaml
@@ -10,9 +10,12 @@ build:
     image: go-hello-world
 deploy:
   kubectl:
-    manifests:
-    - kubernetes-manifests/**
+    manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.yaml"]
 profiles:
 - name: cloudbuild
   build:
     googleCloudBuild: {}
+- name: internalpool # This profile is for running clusters with only internal ip addresses.
+  deploy:
+    kubectl:
+      manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.internal.yaml"]

--- a/java/java-hello-world/kubernetes-manifests/hello.service.internal.yaml
+++ b/java/java-hello-world/kubernetes-manifests/hello.service.internal.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: java-hello-world-internal
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  selector:
+    app: java-hello-world
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/java/java-hello-world/skaffold.yaml
+++ b/java/java-hello-world/skaffold.yaml
@@ -17,8 +17,7 @@ build:
 # defines the Kubernetes manifests to deploy on each run
 deploy:
   kubectl:
-    manifests:
-    - ./kubernetes-manifests/**.yaml
+    manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.yaml"]
 profiles:
 # use the cloudbuild profile to build images using Google Cloud Build
 - name: cloudbuild
@@ -26,6 +25,13 @@ profiles:
     googleCloudBuild: {}
 # use the dockerfile profile to build images using Docker instead of Jib
 - name: dockerfile
+  build:
+    artifacts:
+      - image: java-hello-world
+- name: internalpool # This profile is for running clusters with only internal ip addresses.
+  deploy:
+    kubectl:
+      manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.internal.yaml"]
   build:
     artifacts:
       - image: java-hello-world

--- a/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.internal.yaml
+++ b/nodejs/nodejs-hello-world/kubernetes-manifests/hello.service.internal.yaml
@@ -1,12 +1,14 @@
 # This Service manifest defines:
 # - a load balancer for pods matching label "app: node-hello-world"
-# - exposing the application to the public Internet (type:LoadBalancer)
+# - NOT exposing the application to the public Internet (internal load balancer)
 # - routes port 80 of the load balancer to the port 8080 of the Pods.
 # Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
 apiVersion: v1
 kind: Service
 metadata:
-  name: nodejs-hello-world-external
+  name: nodejs-hello-world-internal
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   selector:

--- a/nodejs/nodejs-hello-world/skaffold.yaml
+++ b/nodejs/nodejs-hello-world/skaffold.yaml
@@ -10,9 +10,12 @@ build:
     image: nodejs-hello-world
 deploy:
   kubectl:
-    manifests:
-    - kubernetes-manifests/**
+    manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.yaml"]
 profiles:
 - name: cloudbuild
   build:
     googleCloudBuild: {}
+- name: internalpool # This profile is for running clusters with internal IP addresses.
+  deploy:
+    kubectl:
+      manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.internal.yaml"]

--- a/python/django/python-hello-world/kubernetes-manifests/hello.service.internal.yaml
+++ b/python/django/python-hello-world/kubernetes-manifests/hello.service.internal.yaml
@@ -1,0 +1,23 @@
+# This Service manifest defines:
+# - a load balancer for pods matching label "app: django-python-hello-world"
+# - NOT exposing the application to the public Internet (internal load balancer)
+# - routes port 80 of the load balancer to the port 8080 of the Pods.
+# Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
+apiVersion: v1
+kind: Service
+metadata:
+  name: django-python-hello-world-internal
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
+  labels:
+    app: django-python-hello-world
+    tier: app
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: django-python-hello-world
+    tier: app

--- a/python/django/python-hello-world/skaffold.yaml
+++ b/python/django/python-hello-world/skaffold.yaml
@@ -12,10 +12,13 @@ build:
 # defines the Kubernetes manifests to deploy on each run
 deploy:
   kubectl:
-    manifests:
-      - kubernetes-manifests/**.yaml
+    manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.yaml"]
 # use the cloudbuild profile to build images using Google Cloud Build
 profiles:
 - name: cloudbuild
   build:
     googleCloudBuild: {}
+- name: internalpool # This profile is for running clusters with internal IP addresses.
+  deploy:
+    kubectl:
+      manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.internal.yaml"]

--- a/python/python-hello-world/kubernetes-manifests/hello.service.internal.yaml
+++ b/python/python-hello-world/kubernetes-manifests/hello.service.internal.yaml
@@ -1,16 +1,18 @@
 # This Service manifest defines:
-# - a load balancer for pods matching label "app: node-hello-world"
-# - exposing the application to the public Internet (type:LoadBalancer)
+# - a load balancer for pods matching label "app: python-hello-world"
+# - NOT exposing the application to the public Internet (internal load balancer)
 # - routes port 80 of the load balancer to the port 8080 of the Pods.
 # Syntax reference https://kubernetes.io/docs/concepts/configuration/overview/
 apiVersion: v1
 kind: Service
 metadata:
-  name: nodejs-hello-world-external
+  name: nodejs-hello-world-internal
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 spec:
   type: LoadBalancer
   selector:
-    app: nodejs-hello-world
+    app: python-hello-world
   ports:
   - name: http
     port: 80

--- a/python/python-hello-world/skaffold.yaml
+++ b/python/python-hello-world/skaffold.yaml
@@ -12,10 +12,13 @@ build:
 # defines the Kubernetes manifests to deploy on each run
 deploy:
   kubectl:
-    manifests:
-    - kubernetes-manifests/**
+    manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.yaml"]
 # use the cloudbuild profile to build images using Google Cloud Build
 profiles:
 - name: cloudbuild
   build:
     googleCloudBuild: {}
+- name: internalpool # This profile is for running clusters with internal IP addresses.
+  deploy:
+    kubectl:
+      manifests: ["kubernetes-manifests/hello.deployment.yaml", "kubernetes-manifests/hello.service.internal.yaml"]


### PR DESCRIPTION
- Adding a profile that uses a service with internal load balancer for testing purposes in node example
- New yaml is added to manifests for this purpose.